### PR TITLE
Add Apollo GraphQL caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2863,6 +2863,66 @@
         "apollo-server-types": "^0.6.3"
       }
     },
+    "apollo-server-plugin-response-cache": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-response-cache/-/apollo-server-plugin-response-cache-0.7.0.tgz",
+      "integrity": "sha512-FLM3cD9sZAC1mKJmoxCTKhnh45ZDJKS2gTe3tQj5Hht/BHowbKdlYUKB1Vz1BV+soewo0O2s7VWXzsOWjP/kJg==",
+      "requires": {
+        "apollo-cache-control": "^0.12.0",
+        "apollo-server-caching": "^0.6.0",
+        "apollo-server-plugin-base": "^0.11.0"
+      },
+      "dependencies": {
+        "apollo-cache-control": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.12.0.tgz",
+          "integrity": "sha512-kClF5rfAm159Nboul1LxA+l58Tjz0M8L1GUknEMpZt0UHhILLAn3BfcG3ToX4TbNoR9M57kKMUcbPWLdy3Up7w==",
+          "requires": {
+            "apollo-server-env": "^3.0.0",
+            "apollo-server-plugin-base": "^0.11.0"
+          }
+        },
+        "apollo-server-caching": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.6.0.tgz",
+          "integrity": "sha512-SfjKaccrhRzUQ8TAke9FrYppp4pZV3Rp8KCs+4Ox3kGtbco68acRPJkiYYtSVc4idR8XNAUOOVfAEZVNHdZQKQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "apollo-server-plugin-base": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.11.0.tgz",
+          "integrity": "sha512-Du68x0XCyQ6EWlgoL9Z+1s8fJfXgY131QbKP7ao617StQPzwB0aGCwxBDfcMt1A75VXf4TkvV1rdUH5YeJFlhQ==",
+          "requires": {
+            "apollo-server-types": "^0.7.0"
+          }
+        },
+        "apollo-server-types": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.7.0.tgz",
+          "integrity": "sha512-pJ6ri2N4xJ+e2PUUPHeCNpMDzHUagJyn0DDZGQmXDz6aoMlSd4B2KUvK81hHyHkw3wHk9clgcpfM9hKqbfZweA==",
+          "requires": {
+            "apollo-reporting-protobuf": "^0.6.2",
+            "apollo-server-caching": "^0.6.0",
+            "apollo-server-env": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "apollo-server-types": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.6.3.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@bugsnag/js": "^6.5.2",
     "@bugsnag/plugin-express": "^6.5.1",
     "apollo-server-express": "^2.19.2",
+    "apollo-server-plugin-response-cache": "^0.7.0",
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.3",

--- a/src/middleware/apolloServer.js
+++ b/src/middleware/apolloServer.js
@@ -1,8 +1,15 @@
 const { ApolloServer } = require('apollo-server-express');
+const responseCachePlugin = require('apollo-server-plugin-response-cache');
 const schema = require('../graphql/schema');
 
 const createApolloMiddleware = async () => {
-  const server = new ApolloServer({ schema });
+  const server = new ApolloServer({
+    schema,
+    plugins: [responseCachePlugin()],
+    cacheControl: {
+      defaultMaxAge: 3600, // 1 hour
+    },
+  });
   return server;
 };
 


### PR DESCRIPTION
## What does this do?
Adds in Apollo's own in-memory caching for GraphQL. It is based on [Apollo's in-memory cache instructions](https://www.apollographql.com/docs/apollo-server/performance/caching/#in-memory-cache-setup) and [their setup for default Max Age](https://www.apollographql.com/docs/apollo-server/performance/caching/#default-maxage).

## How was it tested?
CI and locally. Drops response time by an order of magnitude.

## Is there a Github issue this is resolving?
Nope

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/113493713-ce2d1b80-9496-11eb-991b-333c0aab2e06.png)

