### PR TITLE
Spell name added to spell doc

### DIFF
--- a/src/views/partials/doc-resource-spells.ejs
+++ b/src/views/partials/doc-resource-spells.ejs
@@ -128,6 +128,11 @@
       <td align="left">string</td>
     </tr>
     <tr>
+      <td align="left">name</td>
+      <td align="left">The spell name.</td>
+      <td align="left">string</td>
+    </tr>
+    <tr>
       <td align="left">desc</td>
       <td align="left">A description of the spell.</td>
       <td align="left">list</td>


### PR DESCRIPTION
## What does this do?
Add's the name attribute to spell's documentation table

## How was it tested?
It wasn't.

## Is there a Github issue this is resolving?
No.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
