### PR TITLE
Add full multi-class support

### DIFF
--- a/src/controllers/api/classController.js
+++ b/src/controllers/api/classController.js
@@ -47,7 +47,7 @@ exports.showLevelForClass = (req, res, next) => {
 
 exports.showMulticlassingForClass = (req, res, next) => {
   const urlString = '/api/classes/' + req.params.index;
-  return Class.findOne({ 'classes.url': urlString })
+  return Class.findOne({ url: urlString })
     .then(data => {
       res.status(200).json(data.multi_classing);
     })

--- a/src/controllers/api/classController.js
+++ b/src/controllers/api/classController.js
@@ -45,6 +45,17 @@ exports.showLevelForClass = (req, res, next) => {
     });
 };
 
+exports.showMulticlassingForClass = (req, res, next) => {
+  const urlString = '/api/classes/' + req.params.index;
+  return Class.findOne({ 'classes.url': urlString })
+    .then(data => {
+      res.status(200).json(data.multi_classing);
+    })
+    .catch(err => {
+      next(err);
+    });
+};
+
 exports.showSubclassesForClass = (req, res, next) => {
   const urlString = '/api/classes/' + req.params.index;
   return Subclass.find({ 'class.url': urlString })

--- a/src/models/class.js
+++ b/src/models/class.js
@@ -35,9 +35,28 @@ const Spellcasting = {
   spellcasting_ability: APIReference,
 };
 
+const MultiClassingPrereq = {
+  ability_score: APIReference,
+  minimum_score: { type: Number, index: true },
+};
+
+const MultiClassingPrereqOptions = {
+  choose: { type: Number, index: true },
+  from: [MultiClassingPrereq],
+  type: { type: String, index: true },
+};
+
+const MultiClassing = {
+  prerequisites: [MultiClassingPrereq],
+  prerequisite_options: MultiClassingPrereqOptions,
+  proficiencies: [APIReference],
+  proficiency_choices: [ProficiencyChoice],
+};
+
 const Class = new Schema({
   _id: { type: String, select: false },
   class_levels: { type: String, index: true },
+  multi_classing: MultiClassing,
   hit_die: { type: Number, index: true },
   index: { type: String, index: true },
   name: { type: String, index: true },

--- a/src/routes/api/classes.js
+++ b/src/routes/api/classes.js
@@ -15,6 +15,7 @@ router.get('/:index/spellcasting', ClassController.showSpellcastingForClass);
 router.get('/:index/spells', ClassController.showSpellsForClass);
 router.get('/:index/features', ClassController.showFeaturesForClass);
 router.get('/:index/proficiencies', ClassController.showProficienciesForClass);
+router.get('/:index/multi-classing', ClassController.showMulticlassingForClass);
 
 router.get('/:index/levels/:level/spells', ClassController.showSpellsForClassAndLevel);
 router.get('/:index/levels/:level/features', ClassController.showFeaturesForClassAndLevel);

--- a/src/tests/controllers/api/classController.test.js
+++ b/src/tests/controllers/api/classController.test.js
@@ -386,6 +386,38 @@ describe('showSpellcastingForClass', () => {
   });
 });
 
+describe('showMulticlassingForClass', () => {
+  const findOneDoc = {
+    index: 8,
+    class: 'Warlock',
+    url: '/api/classes/warlock',
+    multi_classing: {
+      some: 'data',
+    },
+  };
+  const request = mockRequest({ params: { index: 'warlock' } });
+
+  it('returns a multi-classing object', async () => {
+    mockingoose(Class).toReturn(findOneDoc, 'findOne');
+
+    await ClassController.showMulticlassingForClass(request, response, mockNext);
+    expect(response.status).toHaveBeenCalledWith(200);
+  });
+
+  describe('when something goes wrong', () => {
+    it('handles the error', async () => {
+      const error = new Error('Something went wrong');
+      mockingoose(Class).toReturn(error, 'findOne');
+
+      await ClassController.showMulticlassingForClass(request, response, mockNext);
+
+      expect(response.status).not.toHaveBeenCalled();
+      expect(response.json).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+  });
+});
+
 describe('showSpellsForClass', () => {
   const findDoc = [
     {

--- a/src/tests/integration/api/classes.itest.js
+++ b/src/tests/integration/api/classes.itest.js
@@ -127,6 +127,16 @@ describe('/api/classes', () => {
       });
     });
 
+    describe('/api/classes/:index/multi-classing', () => {
+      it('returns objects', async () => {
+        const indexRes = await request(app).get('/api/classes');
+        const index = indexRes.body.results[1].index;
+        const res = await request(app).get(`/api/classes/${index}/multi-classing`);
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.results.length).not.toEqual(0);
+      });
+    });
+
     describe('/api/classes/:index/levels', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/classes');

--- a/src/tests/integration/api/classes.itest.js
+++ b/src/tests/integration/api/classes.itest.js
@@ -123,6 +123,7 @@ describe('/api/classes', () => {
         const index = indexRes.body.results[1].index;
         const res = await request(app).get(`/api/classes/${index}/proficiencies`);
         expect(res.statusCode).toEqual(200);
+        expect(res.body.results.length).not.toEqual(0);
       });
     });
 
@@ -132,7 +133,6 @@ describe('/api/classes', () => {
         const index = indexRes.body.results[1].index;
         const res = await request(app).get(`/api/classes/${index}/multi-classing`);
         expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
       });
     });
 

--- a/src/tests/integration/api/classes.itest.js
+++ b/src/tests/integration/api/classes.itest.js
@@ -123,7 +123,6 @@ describe('/api/classes', () => {
         const index = indexRes.body.results[1].index;
         const res = await request(app).get(`/api/classes/${index}/proficiencies`);
         expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
       });
     });
 

--- a/src/views/partials/doc-resource-classes.ejs
+++ b/src/views/partials/doc-resource-classes.ejs
@@ -196,6 +196,30 @@
     }
   ],
   "class_levels": "/api/classes/warlock/levels",
+  "multi_classing": {
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "cha",
+          "name": "CHA",
+          "url": "/api/ability-scores/cha"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "proficiencies": [
+      {
+        "index": "light-armor",
+        "name": "Light Armor",
+        "url": "/api/proficiencies/light-armor"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/proficiencies/simple-weapons"
+      }
+    ]
+  },
   "subclasses": [
     {
       "index": "fiend",
@@ -321,6 +345,13 @@
       <td align="left">string (<a href="#levels">Levels</a>)</td>
     </tr>
     <tr>
+      <td align="left">multi_classing</td>
+      <td align="left">Information on how to multiclass into this class</td>
+      <td align="left">
+        object (<a href="#multi-classing">Multi Classing</a>)
+      </td>
+    </tr>
+    <tr>
       <td align="left">subclasses</td>
       <td align="left">All possible subclasses that this class can specialize in.</td>
       <td align="left">
@@ -412,7 +443,7 @@
   ]
 }</code></pre>
 
-<h3>GET api/classes/{index}/spellcasting</h3>
+<h3 id="#spellcasting">GET api/classes/{index}/spellcasting</h3>
 
 <pre><code>{
     "level": 1,
@@ -610,6 +641,107 @@
         </td>
       </tr>
     </tbody>
+  </tbody>
+</table>
+
+<h3 id="#multi-classing">GET api/classes/{index}/multi-classing/</h3>
+
+<pre><code>{
+  "prerequisites": [
+    {
+      "ability_score": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/ability-scores/cha"
+      },
+      "minimum_score": 13
+    }
+  ],
+  "prerequisite_options": {
+    "type": "ability-scores",
+    "choose": 1,
+    "from": [
+      {
+        "ability_score": {
+          "index": "str",
+          "name": "STR",
+          "url": "/api/ability-scores/str"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ]
+  },
+  "proficiencies": [
+    {
+      "index": "light-armor",
+      "name": "Light Armor",
+      "url": "/api/proficiencies/light-armor"
+    },
+    {
+      "index": "simple-weapons",
+      "name": "Simple Weapons",
+      "url": "/api/proficiencies/simple-weapons"
+    }
+  ],
+  "proficiency_choices": [
+    {
+      "choose": 1,
+      "type": "proficiencies",
+      "from": [
+        {
+          "index": "skill-animal-handling",
+          "name": "Skill: Animal Handling",
+          "url": "/api/proficiencies/skill-animal-handling"
+        },
+        {
+          "index": "skill-athletics",
+          "name": "Skill: Athletics",
+          "url": "/api/proficiencies/skill-athletics"
+        },
+      ]
+    }
+  ]
+}</code></pre>
+
+<h4>Multi-Classing Prerequisites</h4>
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">Name</th>
+      <th align="left">Description</th>
+      <th align="left">Data Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">prerequisites</td>
+      <td align="left">An object of APIReferences to ability scores and minimum scores</td>
+      <td align="left">list(Object)</td>
+    </tr>
+    <tr>
+      <td align="left">prerequisite_options</td>
+      <td align="left">Choice of prerequisites to meet for</td>
+      <td align="left">list <a href="#choices">Choice</a> (Prerequisites)</td>
+    </tr>
+    <tr>
+      <td align="left">proficiencies</td>
+      <td align="left">Proficiencies available when multiclassing</td>
+      <td align="left">list <a href="#apireference">APIReference</a> (<a href="#proficiencies">Proficiencies</a>)</td>
+    </tr>
+    <tr>
+      <td align="left">proficiency_choices</td>
+      <td align="left">A choice of proficiencies that are given when multiclassing</td>
+      <td align="left">list <a href="#choices">Choice</a> (<a href="#proficiencies">Proficiencies</a>)</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## What does this do?
Technically, the API was supporting Multiclassing fields. However, this adds a multi-class specific endpoint and adds it to GraphQL. It also adds 

## How was it tested?
Tested GraphQL locally and added in unit and integration tests.

## Is there a Github issue this is resolving?
None. Raised in Discord.

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/127939252-04157190-37ea-43bf-bee8-2e66b8feecae.png)
