### PR TITLE
Add feats to response from base endpoint that shows available endpoints

### DIFF
--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -7,6 +7,7 @@ const API_INDEX = {
   'damage-types': '/api/damage-types',
   'equipment-categories': '/api/equipment-categories',
   equipment: '/api/equipment',
+  feats: '/api/feats',
   features: '/api/features',
   languages: '/api/languages',
   'magic-items': '/api/magic-items',


### PR DESCRIPTION
## What does this do?
Adds feats to the list of endpoints that a request to the base url of the API shows

## How was it tested?
I added the url for feats and made sure it showed up when hitting the base url with Postman

## Is there a Github issue this is resolving?
No

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
