### PR TITLE
Update doc-resource-classes.ejs

### DIFF
--- a/src/views/partials/doc-resource-classes.ejs
+++ b/src/views/partials/doc-resource-classes.ejs
@@ -1064,7 +1064,8 @@
     </tbody>
 </table>
 
-<h3>GET api/classes/{index}/levels/{integer 1-20}/spells</h3>
+<h3>GET api/classes/{index}/levels/{integer 0-9}/spells</h3>
+<p>Gets spells of a certain spell_level going from cantrip (0) to 9th level that the class indicated by the value in {index} would know </p>
 
 <pre><code>{
   "count": 19,


### PR DESCRIPTION
fixed an issue where `/classes/{index}/levels/{integer 1-20}/spells` was not documented correctly. It should have instead been `../{integer 0-9}/spells`

## What does this do?
Updates documentation

## How was it tested?
I checked get requests on values 1-20 on the API site, and it was pulling by spell level, not class level.

