### PR TITLE
Bagelbits.docker heroku fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ RUN npm install
 
 COPY . /app
 
+RUN npm run build
+
 # Start the main process.
-CMD ["npm", "start"]
+CMD ["node", "dist/src/start.js"]

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: Dockerfile
 run:
-  web: npm start
+  web: node dist/src/start.js


### PR DESCRIPTION
## What does this do?
Heroku falls over and due to memory issues if we try to build on startup, which frankly makes sense when I think about it. Instead, build should be part of the Dockerfile.

## How was it tested?
Deployed to heroku from branch.

## Is there a Github issue this is resolving?
N/A Just random thing.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
