### PR TITLE
Forgot to copy public folder

### DIFF
--- a/tools/copyAssets.ts
+++ b/tools/copyAssets.ts
@@ -3,5 +3,6 @@ import * as shell from 'shelljs';
 shell.mkdir('-p', 'dist');
 
 // Copy all the view templates
-shell.cp('-R', 'src/views', 'dist/src');
 shell.cp('-R', 'src/css', 'dist/src');
+shell.cp('-R', 'src/public', 'dist/src');
+shell.cp('-R', 'src/views', 'dist/src');


### PR DESCRIPTION
## What does this do?
I forgot to copy the public folder which stores the assets for favicon.

## How was it tested?
Locally.

## Is there a Github issue this is resolving?
Not yet but I'm  sure someone would notice

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
