### PR TITLE
WIP ecs: filter spells by level

### DIFF
--- a/src/models/spell.js
+++ b/src/models/spell.js
@@ -43,7 +43,7 @@ const Spell = new Schema({
   heal_at_slot_level: Object,
   higher_level: [String],
   index: String,
-  level: Number,
+  level: { type: Number, index: true },
   material: String,
   name: String,
   range: String,

--- a/src/models/spell.js
+++ b/src/models/spell.js
@@ -25,32 +25,29 @@ const DC = new Schema({
 });
 
 const Spell = new Schema({
-  _id: {
-    type: String,
-    select: false,
-  },
+  _id: { type: String, select: false },
   area_of_effect: AreaOfEffect,
-  attack_type: String,
-  casting_time: String,
+  attack_type: { type: String, index: true },
+  casting_time: { type: String, index: true },
   classes: [APIReference],
-  components: [String],
-  concentration: Boolean,
+  components: { type: [String], index: true },
+  concentration: { type: Boolean, index: true },
   damage: Damage,
   dc: DC,
-  desc: [String],
-  duration: String,
+  desc: { type: [String], index: true },
+  duration: { type: String, index: true },
   // As this has keys that are numbers, we have to use an `Object`, which you can't query subfields
   heal_at_slot_level: Object,
-  higher_level: [String],
-  index: String,
+  higher_level: { type: [String], index: true },
+  index: { type: String, index: true },
   level: { type: Number, index: true },
-  material: String,
-  name: String,
-  range: String,
-  ritual: Boolean,
+  material: { type: String, index: true },
+  name: { type: String, index: true },
+  range: { type: String, index: true },
+  ritual: { type: Boolean, index: true },
   school: APIReference,
   subclasses: [APIReference],
-  url: String,
+  url: { type: String, index: true },
 });
 
 module.exports = mongoose.model('Spell', Spell, 'spells');


### PR DESCRIPTION
## What does this do?
Sets all scalar fields on `Spell` to be indexes. Setting a field as an index prompts mongoose to enable operators on the field when generating resolvers.

https://github.com/graphql-compose/graphql-compose-mongoose#filterhelperargsopts

## How was it tested?
Tested locally via gql debugger
<img width="1512" alt="Screen Shot 2022-03-14 at 3 17 53 AM" src="https://user-images.githubusercontent.com/1425775/158153358-ccec19a6-4d89-43fb-a0b1-3ef14b6a5977.png">

spell operator filters PROD
<img width="1512" alt="Screen Shot 2022-03-14 at 8 36 57 AM" src="https://user-images.githubusercontent.com/1425775/158208237-40e1a4a2-44ff-4aa3-869f-e696b5efa1da.png">

spell operator filters LOCAL
<img width="1512" alt="Screen Shot 2022-03-14 at 8 37 00 AM" src="https://user-images.githubusercontent.com/1425775/158208288-7683c3ea-1ccc-4a53-8898-d4480fe7ab22.png">

## Is there a Github issue this is resolving?
no, came from conversation in the discord #help channel

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
