### PR TITLE
ecshreve: two small tweaks to docs

### DIFF
--- a/src/views/partials/doc-resource-equipment-categories.ejs
+++ b/src/views/partials/doc-resource-equipment-categories.ejs
@@ -55,5 +55,10 @@
       </td>
     </tr>
 
+    <tr>
+      <td align="left">url</td>
+      <td align="left">The URL of the referenced resource.</td>
+      <td align="left">string</td>
+    </tr>
   </tbody>
 </table>

--- a/src/views/partials/doc-resource-equipment.ejs
+++ b/src/views/partials/doc-resource-equipment.ejs
@@ -13,6 +13,7 @@
   "index": "club",
   "name": "Club",
   "equipment_category": {
+    "index": "weapon"
     "name": "Weapon",
     "url": "/api/equipment-categories/weapon",
   },
@@ -75,9 +76,7 @@
       <td align="left">equipment_category</td>
       <td align="left">The category of equipment this falls into.</td>
       <td align="left">
-        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
-          >Equipment Categories</a
-        >)
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>
     </tr>
     <tr>
@@ -126,9 +125,7 @@
       <td align="left">properties</td>
       <td align="left">A list of the properties this weapon has.</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#weapon-properties"
-          >Weapon Properties</a
-        >)
+        list <a href="#apireference">APIReference</a> (<a href="#weapon-properties">Weapon Properties</a>)
       </td>
     </tr>
     <tr>
@@ -143,11 +140,11 @@
 <h4>The following is a response example for a piece of armor</h4>
 
 <pre><code>{
-  "index": "padded",
-  "name": "Padded",
+  "index": "padded-armor",
+  "name": "Padded Armor",
   "equipment_category": {
-    "name": "Armor",
     "index": "armor",
+    "name": "Armor",
     "url": "/api/equipment-categories/armor"
     },
   "armor_category": "Light",
@@ -163,7 +160,7 @@
     "quantity": 5,
     "unit": "gp"
   },
-  "url": "/api/equipment/padded"
+  "url": "/api/equipment/padded-armor"
 }</code></pre>
 
 <h4>Armor</h4>
@@ -190,9 +187,7 @@
       <td align="left">equipment_category</td>
       <td align="left">The category of equipment this falls into.</td>
       <td align="left">
-        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
-          >Equipment Categories</a
-        >)
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>
     </tr>
     <tr>
@@ -281,18 +276,14 @@
       <td align="left">equipment_category</td>
       <td align="left">The category of equipment this falls into.</td>
       <td align="left">
-        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
-          >Equipment Categories</a
-        >)
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>
     </tr>
     <tr>
       <td align="left">gear_category</td>
       <td align="left">The category of adventuring gear this falls into.</td>
       <td align="left">
-        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
-          >Equipment Categories</a
-        >)
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>
     </tr>
     <tr>
@@ -458,18 +449,14 @@
       <td align="left">equipment_category</td>
       <td align="left">The category of equipment this falls into.</td>
       <td align="left">
-        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
-          >Equipment Categories</a
-        >)
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>
     </tr>
     <tr>
       <td align="left">gear_category</td>
       <td align="left">The category of adventuring gear this falls into.</td>
       <td align="left">
-        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
-          >Equipment Categories</a
-        >)
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>
     </tr>
     <tr>

--- a/src/views/partials/doc-resource-proficiencies.ejs
+++ b/src/views/partials/doc-resource-proficiencies.ejs
@@ -34,7 +34,6 @@
   "reference": {
     "name": "Medium armor",
     "index": "medium-armor",
-    "type": "equipment-categories",
     "url": "/api/equipment-categories/medium-armor"
   },
 }</code></pre>
@@ -88,9 +87,8 @@
       <td align="left">reference</td>
       <td align="left">Reference to the related resource</td>
       <td align="left">
-        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
-          >Equipment Categories</a
-        >, <a href="#equipment">Equipment</a>, <a href="#skills">Skills</a>, or
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>, <a
+          href="#equipment">Equipment</a>, <a href="#skills">Skills</a>, or
         <a href="#ability-scores">Ability Scores</a> )
       </td>
     </tr>


### PR DESCRIPTION
## What does this do?
Two tiny tweaks to documentation to bring the docs inline with the actual response.

## How was it tested?
Viewed docs page on localhost, and verified the new descriptions match the shape of what's actually returned from the endpoint.

## Is there a Github issue this is resolving?
no 

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
