### PR TITLE
Put back CORS and fix Redis configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,7 @@ services:
   api:
     environment:
       MONGODB_URI: mongodb://db/5e-database
-      REDIS_HOST: cache
-      REDIS_PORT: 6379
+      REDIS_URL: redis://cache:6379
     build: .
     ports:
       - '3000:3000'

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,8 @@ const limiter = rateLimit({
 
 export default async () => {
   const app = express();
+  // enable cors in preflight
+  app.options('*', cors);
 
   // Middleware stuff
   app.set('view engine', 'ejs');

--- a/src/util/RedisClient.ts
+++ b/src/util/RedisClient.ts
@@ -1,8 +1,6 @@
-import { redisHost, redisPort, redisUsername, redisPassword } from './environmentVariables';
+import { redisUrl } from './environmentVariables';
 import { createClient } from 'redis';
 
 export default createClient({
-  socket: { host: redisHost, port: redisPort },
-  username: redisUsername,
-  password: redisPassword,
+  url: redisUrl,
 });

--- a/src/util/environmentVariables.ts
+++ b/src/util/environmentVariables.ts
@@ -1,9 +1,5 @@
-const redisHost = process.env.REDIS_HOST || 'localhost';
-const redisPort = parseInt(process.env.REDIS_PORT || '6379');
-const redisUsername = process.env.REDIS_USERNAME || '';
-const redisPassword = process.env.REDIS_PASSWORD || '';
 const redisUrl = process.env.HEROKU_REDIS_YELLOW_URL || process.env.REDIS_URL || '';
 const bugsnagApiKey = process.env.BUGSNAG_API_KEY || null;
 const mongodbUri = process.env.MONGODB_URI || 'mongodb://localhost/5e-database';
 
-export { redisUrl, redisHost, redisPort, redisUsername, redisPassword, bugsnagApiKey, mongodbUri };
+export { redisUrl, bugsnagApiKey, mongodbUri };

--- a/src/util/environmentVariables.ts
+++ b/src/util/environmentVariables.ts
@@ -2,7 +2,8 @@ const redisHost = process.env.REDIS_HOST || 'localhost';
 const redisPort = parseInt(process.env.REDIS_PORT || '6379');
 const redisUsername = process.env.REDIS_USERNAME || '';
 const redisPassword = process.env.REDIS_PASSWORD || '';
+const redisUrl = process.env.HEROKU_REDIS_YELLOW_URL || process.env.REDIS_URL || '';
 const bugsnagApiKey = process.env.BUGSNAG_API_KEY || null;
 const mongodbUri = process.env.MONGODB_URI || 'mongodb://localhost/5e-database';
 
-export { redisHost, redisPort, redisUsername, redisPassword, bugsnagApiKey, mongodbUri };
+export { redisUrl, redisHost, redisPort, redisUsername, redisPassword, bugsnagApiKey, mongodbUri };


### PR DESCRIPTION
## What does this do?

The initial symptom  was CORS which I fixed. But the actual issue, is that Heroku updated the Redis instance and the URL but I don't listen to it when the server comes up. So I've switched back to using `REDIS_URL`.

## How was it tested?
CI and also deployed.

## Is there a Github issue this is resolving?
Raised in  Discord

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/159348623-f11b9c81-c36e-441e-ba29-cc007a3efaad.png)
