### PR TITLE
ecshreve: [openapi] - general docs fixes

### DIFF
--- a/src/swagger/parameters/combined.yml
+++ b/src/swagger/parameters/combined.yml
@@ -50,3 +50,5 @@ school-filter:
   $ref: "./query/spells.yml#/school-filter"
 challenge-rating-filter:
   $ref: "./query/monsters.yml#/challenge-rating-filter"
+base-endpoint-index:
+  $ref: "./path/base.yml"

--- a/src/swagger/parameters/path/base.yml
+++ b/src/swagger/parameters/path/base.yml
@@ -1,0 +1,31 @@
+name: endpoint
+in: path
+required: true
+schema:
+  type: string
+  enum:
+    - ability-scores
+    - alignments
+    - backgrounds
+    - classes
+    - conditions
+    - damage-types
+    - equipment
+    - equipment-categories
+    - feats
+    - features
+    - languages
+    - magic-items
+    - magic-schools
+    - monsters
+    - proficiencies
+    - races
+    - rule-sections
+    - rules
+    - skills
+    - spells
+    - subclasses
+    - subraces
+    - traits
+    - weapon-properties
+  example: ability-scores

--- a/src/swagger/parameters/path/equipment.yml
+++ b/src/swagger/parameters/path/equipment.yml
@@ -4,7 +4,7 @@ required: true
 description: |
   The `index` of the equipment to get.
 
-  Available values can be found in the resource list for this endpoint.
+  Available values can be found in the [`ResourceList`](#get-/api/-endpoint-) for `equipment`.
 schema:
   type: string
-example: club
+  example: club

--- a/src/swagger/parameters/path/features.yml
+++ b/src/swagger/parameters/path/features.yml
@@ -4,7 +4,7 @@ required: true
 description: |
   The `index` of the feature to get.
 
-  Available values can be found in the resource list for this endpoint.
+  Available values can be found in the [`ResourceList`](#get-/api/-endpoint-) for `features`.
 schema:
   type: string
 example: action-surge-1-use

--- a/src/swagger/parameters/path/proficiencies.yml
+++ b/src/swagger/parameters/path/proficiencies.yml
@@ -4,7 +4,7 @@ required: true
 description: |
   The `index` of the proficiency to get.
 
-  Available values can be found in the resource list for this endpoint.
+  Available values can be found in the [`ResourceList`](#get-/api/-endpoint-) for `proficiencies`.
 schema:
   type: string
   example: medium-armor

--- a/src/swagger/parameters/path/spells.yml
+++ b/src/swagger/parameters/path/spells.yml
@@ -4,7 +4,7 @@ required: true
 description: |
   The `index` of the `Spell` to get.
 
-  Available values can be found in the resource list for this endpoint.
+  Available values can be found in the [`ResourceList`](#get-/api/-endpoint-) for `spells`.
 schema:
   type: string
   example: sacred-flame

--- a/src/swagger/paths/list.yml
+++ b/src/swagger/paths/list.yml
@@ -1,7 +1,7 @@
 get:
   summary: "Get list of all available resources for an endpoint."
   description: |
-    Currently only the [`/spells`](#get-/api/spells) and [`/monsters`](#get-/api/monsters) endpoints support filtering with query parameters. Use of these query parameters is documented under the respective [Spells](#tag--Spells) and [Monsters](#tag--monsters) sections.
+    Currently only the [`/spells`](#get-/api/spells) and [`/monsters`](#get-/api/monsters) endpoints support filtering with query parameters. Use of these query parameters is documented under the respective [Spells](#tag--Spells) and [Monsters](#tag--Monsters) sections.
   tags:
     - Resource Lists
   parameters:

--- a/src/swagger/paths/list.yml
+++ b/src/swagger/paths/list.yml
@@ -5,36 +5,7 @@ get:
   tags:
     - Resource Lists
   parameters:
-    - name: endpoint
-      in: path
-      required: true
-      schema:
-        type: string
-        enum:
-          - ability-scores
-          - alignments
-          - backgrounds
-          - classes
-          - conditions
-          - damage-types
-          - equipment
-          - equipment-categories
-          - feats
-          - features
-          - languages
-          - magic-items
-          - magic-schools
-          - monsters
-          - proficiencies
-          - races
-          - rule-sections
-          - rules
-          - skills
-          - spells
-          - subclasses
-          - subraces
-          - traits
-          - weapon-properties
+    - $ref: "../parameters/combined.yml#/base-endpoint-index"
   responses:
     "200":
       description: "OK"

--- a/src/swagger/paths/subclasses.yml
+++ b/src/swagger/paths/subclasses.yml
@@ -153,7 +153,7 @@ subclass-levels-path:
             schema:
               type: array
               items:
-                $ref: "../schemas/combined.yml#/SubclassLevel"
+                $ref: "../schemas/combined.yml#/SubclassLevelResource"
 # /api/subclasses/{index}/levels/{subclass_level}:
 subclass-level-path:
   get:

--- a/src/swagger/schemas/ability-scores.yml
+++ b/src/swagger/schemas/ability-scores.yml
@@ -1,15 +1,16 @@
 ability-score-model:
-  description: AbilityScore
+  description: |
+    `AbilityScore`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
     - type: object
       properties:
         full_name:
-          description: "The full name for this ability score."
+          description: "Full name of the ability score."
           type: string
         skills:
-          description: "A list of skills that use this ability score."
+          description: "List of skills that use this ability score."
           type: array
           items:
             $ref: "./combined.yml#/APIReference"
@@ -18,7 +19,7 @@ AbilityBonus:
   type: object
   properties:
     bonus:
-      description: "The bonus amount for this ability score."
+      description: "Bonus amount for this ability score."
       type: number
     ability_score:
       $ref: "./combined.yml#/APIReference"

--- a/src/swagger/schemas/ability-scores.yml
+++ b/src/swagger/schemas/ability-scores.yml
@@ -1,4 +1,5 @@
 ability-score-model:
+  description: AbilityScore
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/alignments.yml
+++ b/src/swagger/schemas/alignments.yml
@@ -1,9 +1,10 @@
-description: Alignment
+description: |
+  `Alignment`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"
   - type: object
     properties:
       abbreviation:
-        description: "The abbreviation/initials/acronym for this alignment resource."
+        description: Abbreviation/initials/acronym for this alignment.
         type: string

--- a/src/swagger/schemas/alignments.yml
+++ b/src/swagger/schemas/alignments.yml
@@ -6,5 +6,5 @@ allOf:
   - type: object
     properties:
       abbreviation:
-        description: Abbreviation/initials/acronym for this alignment.
+        description: Abbreviation/initials/acronym for the alignment.
         type: string

--- a/src/swagger/schemas/alignments.yml
+++ b/src/swagger/schemas/alignments.yml
@@ -1,3 +1,4 @@
+description: Alignment
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/armor.yml
+++ b/src/swagger/schemas/armor.yml
@@ -1,4 +1,5 @@
-description: Armor
+description: |
+  `Armor`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/armor.yml
+++ b/src/swagger/schemas/armor.yml
@@ -1,27 +1,27 @@
-Armor:
-  allOf:
-    - $ref: "./combined.yml#/APIReference"
-    - $ref: "./combined.yml#/ResourceDescription"
-    - type: object
-      properties:
-        equipment_category:
-          $ref: "./combined.yml#/APIReference"
-        armor_category:
-          description: "The category of armor this falls into."
+description: Armor
+allOf:
+  - $ref: "./combined.yml#/APIReference"
+  - $ref: "./combined.yml#/ResourceDescription"
+  - type: object
+    properties:
+      equipment_category:
+        $ref: "./combined.yml#/APIReference"
+      armor_category:
+        description: "The category of armor this falls into."
+        type: string
+      armor_class:
+        description: "Details on how to calculate armor class."
+        type: object
+        additionalProperties:
           type: string
-        armor_class:
-          description: "Details on how to calculate armor class."
-          type: object
-          additionalProperties:
-            type: string
-        str_minimum:
-          description: "Minimum STR required to use this armor."
-          type: number
-        stealth_disadvantage:
-          description: "Whether the armor gives disadvantage for Stealth."
-          type: boolean
-        cost:
-          $ref: "./combined.yml#/Cost"
-        weight:
-          description: "How much the equipment weighs."
-          type: number
+      str_minimum:
+        description: "Minimum STR required to use this armor."
+        type: number
+      stealth_disadvantage:
+        description: "Whether the armor gives disadvantage for Stealth."
+        type: boolean
+      cost:
+        $ref: "./combined.yml#/Cost"
+      weight:
+        description: "How much the equipment weighs."
+        type: number

--- a/src/swagger/schemas/backgrounds.yml
+++ b/src/swagger/schemas/backgrounds.yml
@@ -1,4 +1,5 @@
-description: Background
+description: |
+  `Background`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - type: object
@@ -9,19 +10,19 @@ allOf:
         items:
           $ref: "./combined.yml#/APIReference"
       starting_equipment:
-        description: "The starting equipment a character automatically gets."
+        description: "Starting equipment for all new characters of this background."
         type: array
         items:
           $ref: "./combined.yml#/APIReference"
       starting_equipment_options:
-        description: Starting equipment where the player must choose a certain number from the given list of equipment.
+        description: List of choices of starting equipment for all new characters of thi background.
         type: array
         items:
           $ref: "./combined.yml#/Choice"
       language_options:
         $ref: "./combined.yml#/Choice"
       feature:
-        description: A special feature granted to new characters of this background.
+        description: Special feature granted to new characters of this background.
         type: object
         properties:
           name:

--- a/src/swagger/schemas/backgrounds.yml
+++ b/src/swagger/schemas/backgrounds.yml
@@ -1,3 +1,4 @@
+description: Background
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - type: object

--- a/src/swagger/schemas/backgrounds.yml
+++ b/src/swagger/schemas/backgrounds.yml
@@ -15,7 +15,7 @@ allOf:
         items:
           $ref: "./combined.yml#/APIReference"
       starting_equipment_options:
-        description: List of choices of starting equipment for all new characters of thi background.
+        description: List of choices of starting equipment for all new characters of this background.
         type: array
         items:
           $ref: "./combined.yml#/Choice"

--- a/src/swagger/schemas/classes.yml
+++ b/src/swagger/schemas/classes.yml
@@ -42,51 +42,57 @@ class-model:
           type: array
           items:
             $ref: "./combined.yml#/APIReference"
-ClassLevel:
-  allOf:
-    - $ref: "./combined.yml#/APIReference"
-    - type: object
+class-level-model:
+  description: |
+    `ClassLevel`
+  type: object
+  properties:
+    index:
+      description: "Resource index for shorthand searching."
+      type: string
+    url:
+      description: "URL of the referenced resource."
+      type: string
+    level:
+      description: "The number value for the current level object."
+      type: number
+    ability_score_bonuses:
+      description: "Total number of ability score bonuses gained, added from previous levels."
+      type: number
+    prof_bonus:
+      description: "Proficiency bonus for this class at the specified level."
+      type: number
+    features:
+      description: "Features automatically gained at this level."
+      type: array
+      items:
+        $ref: "./combined.yml#/APIReference"
+    spellcasting:
+      description: "Summary of spells known at this level."
+      type: object
       properties:
-        level:
-          description: "The number value for the current level object."
+        cantrips_known:
           type: number
-        ability_score_bonuses:
-          description: "Total number of ability score bonuses gained, added from previous levels."
+        spells_known:
           type: number
-        prof_bonus:
-          description: "Proficiency bonus for this class at the specified level."
+        spell_slots_level_1:
           type: number
-        features:
-          description: "Features automatically gained at this level."
-          type: array
-          items:
-            $ref: "./combined.yml#/APIReference"
-        spellcasting:
-          description: "Summary of spells known at this level."
-          type: object
-          properties:
-            cantrips_known:
-              type: number
-            spells_known:
-              type: number
-            spell_slots_level_1:
-              type: number
-            spell_slots_level_2:
-              type: number
-            spell_slots_level_3:
-              type: number
-            spell_slots_level_4:
-              type: number
-            spell_slots_level_5:
-              type: number
-            spell_slots_level_6:
-              type: number
-            spell_slots_level_7:
-              type: number
-            spell_slots_level_8:
-              type: number
-            spell_slots_level_9:
-              type: number
-        classspecific:
-          description: "Class specific information such as dice values for bard songs and number of warlock invocations."
-          additionalProperties: {}
+        spell_slots_level_2:
+          type: number
+        spell_slots_level_3:
+          type: number
+        spell_slots_level_4:
+          type: number
+        spell_slots_level_5:
+          type: number
+        spell_slots_level_6:
+          type: number
+        spell_slots_level_7:
+          type: number
+        spell_slots_level_8:
+          type: number
+        spell_slots_level_9:
+          type: number
+    classspecific:
+      description: "Class specific information such as dice values for bard songs and number of warlock invocations."
+      additionalProperties: {}

--- a/src/swagger/schemas/classes.yml
+++ b/src/swagger/schemas/classes.yml
@@ -1,47 +1,44 @@
 class-model:
-  description: Class
+  description: |
+    `Class`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - type: object
       properties:
         hit_die:
-          description: "The hit die of the class. (ex: 12 == 1d12)."
+          description: "Hit die of the class. (ex: 12 == 1d12)."
           type: number
         class_levels:
-          description: "The URL of the class's level resource."
+          description: URL of the level resource for the class.
           type: string
         multi_classing:
           $ref: "./combined.yml#/Multiclassing"
         spellcasting:
           $ref: "./combined.yml#/Spellcasting"
         spells:
-          description: "The URL of the class's spell resource list."
+          description: URL of the spell resource list for the class."
           type: string
         starting_equipment:
-          description: "An object with the possible choices of equipment for new characters of this class."
-          type: object
-          properties:
-            equipment:
-              $ref: "./combined.yml#/APIReference"
-            quantity:
-              type: number
+          description: Choices of starting equipment.
+          allOf:
+            - $ref: "./combined.yml#/Choice"
         proficiency_choices:
-          description: "Starting proficiencies where the player must choose a certain number from the given list of proficiencies."
+          description: List of choices of starting proficiencies.
           type: array
           items:
             $ref: "./combined.yml#/Choice"
         proficiencies:
-          description: "Starting proficiencies all new characters of this class start with."
+          description: List of starting proficiencies for all new characters of this class.
           type: array
           items:
             $ref: "./combined.yml#/APIReference"
         saving_throws:
-          description: "Saving throws that the class is proficient in."
+          description: Saving throws the class is proficient in.
           type: array
           items:
             $ref: "./combined.yml#/APIReference"
         subclasses:
-          description: "All possible subclasses that this class can specialize in."
+          description: List of all possible subclasses this class can specialize in.
           type: array
           items:
             $ref: "./combined.yml#/APIReference"

--- a/src/swagger/schemas/classes.yml
+++ b/src/swagger/schemas/classes.yml
@@ -1,4 +1,5 @@
-Class:
+class-model:
+  description: Class
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - type: object

--- a/src/swagger/schemas/classes.yml
+++ b/src/swagger/schemas/classes.yml
@@ -93,6 +93,6 @@ class-level-model:
           type: number
         spell_slots_level_9:
           type: number
-    classspecific:
+    class_specific:
       description: "Class specific information such as dice values for bard songs and number of warlock invocations."
       additionalProperties: {}

--- a/src/swagger/schemas/classes.yml
+++ b/src/swagger/schemas/classes.yml
@@ -16,7 +16,7 @@ class-model:
         spellcasting:
           $ref: "./combined.yml#/Spellcasting"
         spells:
-          description: URL of the spell resource list for the class."
+          description: URL of the spell resource list for the class.
           type: string
         starting_equipment:
           description: Choices of starting equipment.

--- a/src/swagger/schemas/combined.yml
+++ b/src/swagger/schemas/combined.yml
@@ -55,7 +55,9 @@ Feat:
 Subclass:
   $ref: "./subclass.yml#/subclass-model"
 SubclassLevel:
-  $ref: "./subclass.yml#/SubclassLevel"
+  $ref: "./subclass.yml#/subclass-level-model"
+SubclassLevelResource:
+  $ref: "./subclass.yml#/subclass-level-resource-model"
 ClassLevel:
   $ref: "./classes.yml#/ClassLevel"
 Feature:

--- a/src/swagger/schemas/combined.yml
+++ b/src/swagger/schemas/combined.yml
@@ -78,5 +78,5 @@ RuleSection:
   $ref: "./rules.yml#/rule-section-model"
 Monster:
   $ref: "./monsters.yml#/monster-model"
-SpellPrereq:
-  $ref: "./subclass.yml#/SpellPrereq"
+SpellPrerequisite:
+  $ref: "./subclass.yml#/spell-prerequisite"

--- a/src/swagger/schemas/combined.yml
+++ b/src/swagger/schemas/combined.yml
@@ -59,7 +59,7 @@ SubclassLevel:
 SubclassLevelResource:
   $ref: "./subclass.yml#/subclass-level-resource-model"
 ClassLevel:
-  $ref: "./classes.yml#/ClassLevel"
+  $ref: "./classes.yml#/class-level-model"
 Feature:
   $ref: "./features.yml"
 Race:

--- a/src/swagger/schemas/combined.yml
+++ b/src/swagger/schemas/combined.yml
@@ -1,47 +1,47 @@
 APIReference:
-  $ref: "./common.yml#/APIReference"
+  $ref: "./common.yml#/api-ref-model"
 APIReferenceList:
-  $ref: "./common.yml#/APIReferenceList"
+  $ref: "./common.yml#/api-ref-list-model"
 Choice:
-  $ref: "./common.yml#/Choice"
+  $ref: "./common.yml#/choice-model"
 Prerequisite:
-  $ref: "./common.yml#/Prerequisite"
+  $ref: "./common.yml#/prerequisite-model"
 ResourceDescription:
-  $ref: "./common.yml#/ResourceDescription"
+  $ref: "./common.yml#/resource-description-model"
 AbilityScore:
   $ref: "./ability-scores.yml#/ability-score-model"
 Alignment:
   $ref: "./alignments.yml"
 Class:
-  $ref: "./classes.yml#/Class"
+  $ref: "./classes.yml#/class-model"
 Damage:
-  $ref: "./common.yml#/Damage"
+  $ref: "./common.yml#/damage-model"
 Multiclassing:
   $ref: "./multiclassing.yml"
 Spellcasting:
   $ref: "./spellcasting.yml"
 Gear:
-  $ref: "./equipment.yml#/Gear"
+  $ref: "./equipment.yml#/gear-model"
 EquipmentPack:
-  $ref: "./equipment.yml#/EquipmentPack"
+  $ref: "./equipment.yml#/equipment-pack-model"
 EquipmentCategory:
-  $ref: "./equipment.yml#/EquipmentCategory"
+  $ref: "./equipment.yml#/equipment-category-model"
 Equipment:
-  $ref: "./equipment.yml#/Equipment"
+  $ref: "./equipment.yml#/equipment-model"
 Cost:
-  $ref: "./common.yml#/Cost"
+  $ref: "./common.yml#/cost-model"
 Weapon:
-  $ref: "./weapon.yml#/Weapon"
+  $ref: "./weapon.yml#/weapon-model"
 Armor:
-  $ref: "./armor.yml#/Armor"
+  $ref: "./armor.yml"
 MagicItem:
-  $ref: "./equipment.yml#/MagicItem"
+  $ref: "./equipment.yml#/magic-item-model"
 DamageType:
-  $ref: "./game-mechanics.yml#/DamageType"
+  $ref: "./game-mechanics.yml#/damage-type-model"
 Condition:
-  $ref: "./game-mechanics.yml#/Condition"
+  $ref: "./game-mechanics.yml#/condition-model"
 MagicSchool:
-  $ref: "./game-mechanics.yml#/MagicSchool"
+  $ref: "./game-mechanics.yml#/magic-school-model"
 Skill:
   $ref: "./skills.yml"
 Proficiency:
@@ -53,7 +53,7 @@ Background:
 Feat:
   $ref: "./feats.yml"
 Subclass:
-  $ref: "./subclass.yml#/Subclass"
+  $ref: "./subclass.yml#/subclass-model"
 SubclassLevel:
   $ref: "./subclass.yml#/SubclassLevel"
 ClassLevel:
@@ -71,12 +71,12 @@ Subrace:
 Trait:
   $ref: "./traits.yml#/trait"
 WeaponProperty:
-  $ref: "./weapon.yml#/WeaponProperty"
+  $ref: "./weapon.yml#/weapon-property-model"
 Rule:
-  $ref: "./rules.yml#/Rule"
+  $ref: "./rules.yml#/rule-model"
 RuleSection:
-  $ref: "./rules.yml#/RuleSection"
+  $ref: "./rules.yml#/rule-section-model"
 Monster:
-  $ref: "./monsters.yml#/Monster"
+  $ref: "./monsters.yml#/monster-model"
 SpellPrereq:
   $ref: "./subclass.yml#/SpellPrereq"

--- a/src/swagger/schemas/common.yml
+++ b/src/swagger/schemas/common.yml
@@ -1,4 +1,4 @@
-APIReference:
+api-ref-model:
   description: APIReference
   type: object
   properties:
@@ -11,7 +11,7 @@ APIReference:
     url:
       description: "The URL of the referenced resource."
       type: string
-APIReferenceList:
+api-ref-list-model:
   type: object
   properties:
     count:
@@ -20,9 +20,9 @@ APIReferenceList:
     results:
       type: array
       items:
-        $ref: "#/APIReference"
-Choice:
-  description: An option to select items from a list.
+        $ref: "./combined.yml#/APIReference"
+choice-model:
+  description: Choice
   type: object
   properties:
     choose:
@@ -35,8 +35,9 @@ Choice:
       description: "A list of resources to choose from."
       type: array
       items:
-        $ref: "#/APIReference"
-Cost:
+        $ref: "./combined.yml#/APIReference"
+cost-model:
+  description: Cost
   type: object
   properties:
     quantity:
@@ -45,14 +46,16 @@ Cost:
     unit:
       description: "The unit of coinage."
       type: string
-Damage:
+damage-model:
+  description: Damage
   type: object
   properties:
     damage_dice:
       type: string
     damage_type:
       $ref: "./combined.yml#/APIReference"
-Prerequisite:
+prerequisite-model:
+  description: Prerequisite
   type: object
   properties:
     ability_score:
@@ -60,7 +63,8 @@ Prerequisite:
         - $ref: "./combined.yml#/APIReference"
     minimum_score:
       type: number
-ResourceDescription:
+resource-description-model:
+  description: Description
   type: object
   properties:
     desc:

--- a/src/swagger/schemas/common.yml
+++ b/src/swagger/schemas/common.yml
@@ -1,15 +1,16 @@
 api-ref-model:
-  description: APIReference
+  description: |
+    `APIReference`
   type: object
   properties:
     index:
-      description: "The resource index for shorthand searching."
+      description: "Resource index for shorthand searching."
       type: string
     name:
-      description: "The name of the referenced resource."
+      description: "Name of the referenced resource."
       type: string
     url:
-      description: "The URL of the referenced resource."
+      description: "URL of the referenced resource."
       type: string
 api-ref-list-model:
   type: object
@@ -22,32 +23,35 @@ api-ref-list-model:
       items:
         $ref: "./combined.yml#/APIReference"
 choice-model:
-  description: Choice
+  description: |
+    `Choice`
   type: object
   properties:
     choose:
-      description: "The number of items to pick from the list."
+      description: "Number of items to pick from the list."
       type: number
     type:
-      description: "The type of the resources to choose from."
+      description: "Type of the resources to choose from."
       type: string
     from:
-      description: "A list of resources to choose from."
+      description: "List of resources to choose from."
       type: array
       items:
         $ref: "./combined.yml#/APIReference"
 cost-model:
-  description: Cost
+  description: |
+    `Cost`
   type: object
   properties:
     quantity:
-      description: "The numerical amount of coins."
+      description: "Numerical amount of coins."
       type: number
     unit:
-      description: "The unit of coinage."
+      description: "Unit of coinage."
       type: string
 damage-model:
-  description: Damage
+  description: |
+    `Damage`
   type: object
   properties:
     damage_dice:
@@ -55,20 +59,21 @@ damage-model:
     damage_type:
       $ref: "./combined.yml#/APIReference"
 prerequisite-model:
-  description: Prerequisite
+  description: |
+    `Prerequisite`
   type: object
   properties:
     ability_score:
       allOf:
         - $ref: "./combined.yml#/APIReference"
     minimum_score:
+      description: Minimum score to meet the prerequisite.
       type: number
 resource-description-model:
-  description: Description
   type: object
   properties:
     desc:
-      description: "The description of resource."
+      description: "Description of the resource."
       type: array
       items:
         type: string

--- a/src/swagger/schemas/common.yml
+++ b/src/swagger/schemas/common.yml
@@ -16,7 +16,7 @@ api-ref-list-model:
   type: object
   properties:
     count:
-      description: "Total number of resource available."
+      description: "Total number of resources available."
       type: number
     results:
       type: array

--- a/src/swagger/schemas/equipment.yml
+++ b/src/swagger/schemas/equipment.yml
@@ -1,10 +1,12 @@
-Equipment:
+equipment-model:
+  description: Equipment
   oneOf:
     - $ref: "./combined.yml#/Weapon"
     - $ref: "./combined.yml#/Armor"
-    - $ref: "#/Gear"
-    - $ref: "#/EquipmentPack"
-EquipmentCategory:
+    - $ref: "./combined.yml#/Gear"
+    - $ref: "./combined.yml#/EquipmentPack"
+equipment-category-model:
+  description: EquipmentCategory
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - type: object
@@ -14,7 +16,8 @@ EquipmentCategory:
           type: array
           items:
             $ref: "./combined.yml#/APIReference"
-Gear:
+gear-model:
+  description: Gear
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
@@ -29,7 +32,8 @@ Gear:
         weight:
           description: "How much the equipment weighs."
           type: number
-EquipmentPack:
+equipment-pack-model:
+  description: EquipmentPack
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
@@ -46,7 +50,8 @@ EquipmentPack:
           type: array
           items:
             $ref: "./combined.yml#/APIReference"
-MagicItem:
+magic-item-model:
+  description: MagicItem
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - type: object

--- a/src/swagger/schemas/equipment.yml
+++ b/src/swagger/schemas/equipment.yml
@@ -1,12 +1,14 @@
 equipment-model:
-  description: Equipment
+  description: |
+    `Equipment`
   oneOf:
     - $ref: "./combined.yml#/Weapon"
     - $ref: "./combined.yml#/Armor"
     - $ref: "./combined.yml#/Gear"
     - $ref: "./combined.yml#/EquipmentPack"
 equipment-category-model:
-  description: EquipmentCategory
+  description: |
+    `EquipmentCategory`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - type: object
@@ -17,7 +19,8 @@ equipment-category-model:
           items:
             $ref: "./combined.yml#/APIReference"
 gear-model:
-  description: Gear
+  description: |
+    `Gear`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
@@ -33,7 +36,8 @@ gear-model:
           description: "How much the equipment weighs."
           type: number
 equipment-pack-model:
-  description: EquipmentPack
+  description: |
+    `EquipmentPack`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
@@ -51,7 +55,8 @@ equipment-pack-model:
           items:
             $ref: "./combined.yml#/APIReference"
 magic-item-model:
-  description: MagicItem
+  description: |
+    `MagicItem`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - type: object

--- a/src/swagger/schemas/feats.yml
+++ b/src/swagger/schemas/feats.yml
@@ -1,4 +1,5 @@
-description: Feat
+description: |
+  `Feat`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/feats.yml
+++ b/src/swagger/schemas/feats.yml
@@ -1,3 +1,4 @@
+description: Feat
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/features.yml
+++ b/src/swagger/schemas/features.yml
@@ -1,3 +1,4 @@
+description: Feature
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/features.yml
+++ b/src/swagger/schemas/features.yml
@@ -1,4 +1,5 @@
-description: Feature
+description: |
+  `Feature`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/game-mechanics.yml
+++ b/src/swagger/schemas/game-mechanics.yml
@@ -1,15 +1,18 @@
 damage-type-model:
-  description: DamageType
+  description: |
+    `DamageType`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
 condition-model:
-  description: Condition
+  description: |
+    `Condition`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
 magic-school-model:
-  description: MagicSchool
+  description: |
+    `MagicSchool`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - type: object

--- a/src/swagger/schemas/game-mechanics.yml
+++ b/src/swagger/schemas/game-mechanics.yml
@@ -1,12 +1,15 @@
-DamageType:
+damage-type-model:
+  description: DamageType
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
-Condition:
+condition-model:
+  description: Condition
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
-MagicSchool:
+magic-school-model:
+  description: MagicSchool
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - type: object

--- a/src/swagger/schemas/language.yml
+++ b/src/swagger/schemas/language.yml
@@ -1,4 +1,5 @@
-description: Language
+description: |
+  `Language`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - type: object
@@ -7,13 +8,13 @@ allOf:
         description: "Brief description of the language."
         type: string
       type:
-        description: "Whether the language is standard or exotic."
         type: string
+        enum: [standard, exotic]
       script:
-        description: "The script used for writing in this language."
+        description: "Script used for writing in the language."
         type: string
       typical_speakers:
-        description: "Races that tend to speak this language."
+        description: "List of races that tend to speak the language."
         type: array
         items:
           type: string

--- a/src/swagger/schemas/language.yml
+++ b/src/swagger/schemas/language.yml
@@ -1,3 +1,4 @@
+description: Language
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - type: object

--- a/src/swagger/schemas/monsters.yml
+++ b/src/swagger/schemas/monsters.yml
@@ -180,7 +180,8 @@ monster-special-ability:
       $ref: "#/monster-usage"
 
 monster-model:
-  description: Monster
+  description: |
+    `Monster`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/monsters.yml
+++ b/src/swagger/schemas/monsters.yml
@@ -179,8 +179,8 @@ monster-special-ability:
     usage:
       $ref: "#/monster-usage"
 
-Monster:
-  description: Description of a `Monster` object.
+monster-model:
+  description: Monster
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/multiclassing.yml
+++ b/src/swagger/schemas/multiclassing.yml
@@ -1,4 +1,4 @@
-description: "Information on how to multiclass for a particular class."
+description: "Multiclassing"
 type: object
 properties:
   prerequisites:

--- a/src/swagger/schemas/multiclassing.yml
+++ b/src/swagger/schemas/multiclassing.yml
@@ -1,22 +1,24 @@
-description: "Multiclassing"
+description: |
+  `Multiclassing`
 type: object
 properties:
   prerequisites:
+    description: List of prerequisites that must be met.
     type: array
     items:
       $ref: "./combined.yml#/Prerequisite"
   prerequisite_options:
-    description: Choice of prerequisites to meet for.
+    description: List of choices of prerequisites to meet for.
     type: array
     items:
       $ref: "./combined.yml#/Choice"
   proficiencies:
-    description: "Proficiencies available when multiclassing."
+    description: "List of proficiencies available when multiclassing."
     type: array
     items:
       $ref: "./combined.yml#/APIReference"
   proficiency_choices:
-    description: A list of choices of proficiencies that are given when multiclassing.
+    description: List of choices of proficiencies that are given when multiclassing.
     type: array
     items:
       $ref: "./combined.yml#/Choice"

--- a/src/swagger/schemas/proficiencies.yml
+++ b/src/swagger/schemas/proficiencies.yml
@@ -1,4 +1,5 @@
-description: Proficiency
+description: |
+  `Proficiency`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - type: object

--- a/src/swagger/schemas/proficiencies.yml
+++ b/src/swagger/schemas/proficiencies.yml
@@ -4,17 +4,20 @@ allOf:
   - type: object
     properties:
       type:
-        description: "The general category of the proficiency."
+        description: The general category of the proficiency.
         type: string
       classes:
-        description: "Classes that start with this proficiency."
+        description: Classes that start with this proficiency.
         type: array
         items:
           $ref: "./combined.yml#/APIReference"
       races:
-        description: "Races that start with this proficiency."
+        description: Races that start with this proficiency.
         type: array
         items:
           $ref: "./combined.yml#/APIReference"
       reference:
-        $ref: "./combined.yml#/APIReference"
+        description: |
+          `APIReference` to the full description of the related resource.
+        allOf:
+          - $ref: "./combined.yml#/APIReference"

--- a/src/swagger/schemas/proficiencies.yml
+++ b/src/swagger/schemas/proficiencies.yml
@@ -1,3 +1,4 @@
+description: Proficiency
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - type: object

--- a/src/swagger/schemas/races.yml
+++ b/src/swagger/schemas/races.yml
@@ -1,3 +1,4 @@
+description: Race
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - type: object

--- a/src/swagger/schemas/races.yml
+++ b/src/swagger/schemas/races.yml
@@ -1,4 +1,5 @@
-description: Race
+description: |
+  `Race`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - type: object

--- a/src/swagger/schemas/rules.yml
+++ b/src/swagger/schemas/rules.yml
@@ -1,17 +1,19 @@
 rule-model:
-  description: Rule
+  description: |
+    `Rule`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
     - type: object
       properties:
         subsections:
-          description: "Sections for each subheading underneath the rule in the SRD."
+          description: "List of sections for each subheading underneath the rule in the SRD."
           type: array
           items:
             $ref: "./combined.yml#/APIReference"
 rule-section-model:
-  description: RuleSection
+  description: |
+    `RuleSection`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/rules.yml
+++ b/src/swagger/schemas/rules.yml
@@ -1,4 +1,5 @@
-Rule:
+rule-model:
+  description: Rule
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
@@ -9,7 +10,8 @@ Rule:
           type: array
           items:
             $ref: "./combined.yml#/APIReference"
-RuleSection:
+rule-section-model:
+  description: RuleSection
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/skills.yml
+++ b/src/swagger/schemas/skills.yml
@@ -1,4 +1,5 @@
-description: Skill
+description: |
+  `Skill`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/skills.yml
+++ b/src/swagger/schemas/skills.yml
@@ -1,3 +1,4 @@
+description: Skill
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/spell.yml
+++ b/src/swagger/schemas/spell.yml
@@ -1,22 +1,30 @@
-description: Spell
+description: |
+  `Spell`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"
   - type: object
     properties:
       higher_level:
-        description: "Description for casting the spell at a higher level."
+        description: "List of descriptions for casting the spell at higher levels."
         type: array
         items:
           type: string
       range:
-        description: "The range of the spell."
+        description: "Range of the spell, usually expressed in feet."
         type: string
       components:
-        description: "The required components for a spell are shorthanded to V,S, and M which stand for verbal, somatic, and material."
-        type: string
+        description: |
+          List of shorthand for required components of the spell.
+          V: verbal
+          S: somatic
+          M: material
+        type: array
+        items:
+          type: string
+          enum: [V, S, M]
       material:
-        description: "The material component for the spell to be cast."
+        description: "TMaterial component for the spell to be cast."
         type: string
       ritual:
         description: "Determines if a spell can be cast in a 10-min(in-game) ritual."
@@ -31,10 +39,10 @@ allOf:
         description: "How long it takes for the spell to activate."
         type: string
       level:
-        description: "The level of the spell."
+        description: "Level of the spell."
         type: number
       attack_type:
-        description: "The attack type of the spell."
+        description: "Attack type of the spell."
         type: string
       damage:
         type: object
@@ -45,15 +53,15 @@ allOf:
           damage_type:
             $ref: "./combined.yml#/APIReference"
       school:
-        description: "The magic school this spell belongs to."
+        description: "Magic school this spell belongs to."
         $ref: "./combined.yml#/APIReference"
       classes:
-        description: "The classes that are able to learn this spell."
+        description: "List of classes that are able to learn the spell."
         type: array
         items:
           $ref: "./combined.yml#/APIReference"
       subclasses:
-        description: "A list of subclasses that have access to this spell."
+        description: "List of subclasses that have access to the spell."
         type: array
         items:
           $ref: "./combined.yml#/APIReference"

--- a/src/swagger/schemas/spell.yml
+++ b/src/swagger/schemas/spell.yml
@@ -24,7 +24,7 @@ allOf:
           type: string
           enum: [V, S, M]
       material:
-        description: "TMaterial component for the spell to be cast."
+        description: "Material component for the spell to be cast."
         type: string
       ritual:
         description: "Determines if a spell can be cast in a 10-min(in-game) ritual."

--- a/src/swagger/schemas/spell.yml
+++ b/src/swagger/schemas/spell.yml
@@ -1,4 +1,4 @@
-description: "A spell is a discrete magical effect, a single shaping of the magical energies that suffuse the multiverse into a specific, limited expression."
+description: Spell
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/spellcasting.yml
+++ b/src/swagger/schemas/spellcasting.yml
@@ -1,8 +1,9 @@
 type: object
-description: Spellcasting
+description: |
+  `Spellcasting`
 properties:
   level:
-    description: "The level at which the class can start using its Spellcasting abilities."
+    description: Level at which the class can start using its spellcasting abilities.
     type: number
   info:
     description: "Descriptions of the class' ability to cast spells."
@@ -19,6 +20,6 @@ properties:
           items:
             type: string
   spellcasting_ability:
-    description: Reference to the attribute used for spellcasting by the class.
+    description: Reference to the `AbilityScore` used for spellcasting by the class.
     allOf:
       - $ref: "./combined.yml#/APIReference"

--- a/src/swagger/schemas/spellcasting.yml
+++ b/src/swagger/schemas/spellcasting.yml
@@ -1,5 +1,5 @@
 type: object
-description: Contains information such as spells known, spellcasting ability, and cantrips known.
+description: Spellcasting
 properties:
   level:
     description: "The level at which the class can start using its Spellcasting abilities."

--- a/src/swagger/schemas/subclass.yml
+++ b/src/swagger/schemas/subclass.yml
@@ -1,4 +1,6 @@
-SpellPrereq:
+spell-prerequisite:
+  description: |
+    `SpellPrerequisite`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - type: object
@@ -8,7 +10,8 @@ SpellPrereq:
           type: string
 
 subclass-model:
-  description: Subclass
+  description: |
+    `Subclass`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
@@ -17,10 +20,10 @@ subclass-model:
         class:
           $ref: "./combined.yml#/APIReference"
         subclass_flavor:
-          description: The lore-friendly flavor text for a classes respective subclass.
+          description: Lore-friendly flavor text for a classes respective subclass.
           type: string
         subclass_levels:
-          description: A resource url that shows the subclass level progression.
+          description: Resource url that shows the subclass level progression.
           type: string
         spells:
           type: array
@@ -30,20 +33,20 @@ subclass-model:
               prerequisites:
                 type: array
                 items:
-                  $ref: "./combined.yml#/SpellPrereq"
+                  $ref: "./combined.yml#/SpellPrerequisite"
               spell:
                 $ref: "./combined.yml#/APIReference"
 SubclassLevel:
   type: object
   properties:
     index:
-      description: "The resource index for shorthand searching."
+      description: "Resource index for shorthand searching."
       type: string
     url:
-      description: "The URL of the referenced resource."
+      description: "URL of the referenced resource."
       type: string
     level:
-      description: "The number value for the current level object."
+      description: "Number value for the current level object."
       type: number
     ability_score_bonuses:
       description: "Total number of ability score bonuses gained, added from previous levels."

--- a/src/swagger/schemas/subclass.yml
+++ b/src/swagger/schemas/subclass.yml
@@ -36,7 +36,26 @@ subclass-model:
                   $ref: "./combined.yml#/SpellPrerequisite"
               spell:
                 $ref: "./combined.yml#/APIReference"
-SubclassLevel:
+subclass-level-resource-model:
+  type: object
+  properties:
+    index:
+      type: string
+    url:
+      type: string
+    level:
+      type: number
+    features:
+      type: array
+      items:
+        $ref: "./combined.yml#/APIReference"
+    class:
+      $ref: "./combined.yml#/APIReference"
+    subclass:
+      $ref: "./combined.yml#/APIReference"
+subclass-level-model:
+  description: |
+    `SubclassLevel`
   type: object
   properties:
     index:
@@ -55,7 +74,7 @@ SubclassLevel:
       description: "Proficiency bonus for this class at the specified level."
       type: number
     features:
-      description: "Features automatically gained at this level."
+      description: List of features gained at this level.
       type: array
       items:
         $ref: "./combined.yml#/APIReference"

--- a/src/swagger/schemas/subclass.yml
+++ b/src/swagger/schemas/subclass.yml
@@ -7,8 +7,8 @@ SpellPrereq:
           description: The type of prerequisite.
           type: string
 
-Subclass:
-  description: "A path a class may take as levels are gained."
+subclass-model:
+  description: Subclass
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/subrace.yml
+++ b/src/swagger/schemas/subrace.yml
@@ -1,4 +1,4 @@
-description: "subrace"
+description: Subrace
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/subrace.yml
+++ b/src/swagger/schemas/subrace.yml
@@ -1,32 +1,33 @@
-description: Subrace
+description: |
+  `Subrace`
 allOf:
   - $ref: "./combined.yml#/APIReference"
   - $ref: "./combined.yml#/ResourceDescription"
   - type: object
     properties:
       race:
-        description: "The parent race for this subrace."
+        description: "Parent race for the subrace."
         type: number
       ability_bonuses:
-        description: "Additional ability bonuses for this subrace."
+        description: "Additional ability bonuses for the subrace."
         type: array
         items:
           $ref: "./combined.yml#/AbilityBonus"
       starting_proficiencies:
-        description: "Starting proficiencies for all new characters of this subrace."
+        description: "Starting proficiencies for all new characters of the subrace."
         type: array
         items:
           $ref: "./combined.yml#/APIReference"
       languages:
-        description: "Starting languages for all new characters of this subrace."
+        description: "Starting languages for all new characters of the subrace."
         type: array
         items:
           $ref: "./combined.yml#/APIReference"
       language_options:
-        description: "The starting languages to choose from for this subrace."
+        description: "Starting languages to choose from for the subrace."
         $ref: "./combined.yml#/Choice"
       racial_traits:
-        description: "Racial traits that provide benefits to its members."
+        description: "List of traits that for the subrace."
         type: array
         items:
           $ref: "./combined.yml#/APIReference"

--- a/src/swagger/schemas/traits.yml
+++ b/src/swagger/schemas/traits.yml
@@ -56,7 +56,7 @@ trait-damage:
             type:
               type: string
 trait:
-  description: Description of a `Trait` object.
+  description: Trait
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/traits.yml
+++ b/src/swagger/schemas/traits.yml
@@ -56,7 +56,8 @@ trait-damage:
             type:
               type: string
 trait:
-  description: Trait
+  description: |
+    `Trait`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/weapon.yml
+++ b/src/swagger/schemas/weapon.yml
@@ -1,4 +1,5 @@
-Weapon:
+weapon-model:
+  description: Weapon
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"
@@ -38,7 +39,8 @@ Weapon:
         weight:
           description: "How much the equipment weighs."
           type: number
-WeaponProperty:
+weapon-property-model:
+  description: WeaponProperty
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"

--- a/src/swagger/schemas/weapon.yml
+++ b/src/swagger/schemas/weapon.yml
@@ -1,5 +1,6 @@
 weapon-model:
-  description: Weapon
+  description: |
+    `Weapon`
   allOf:
     - $ref: "./combined.yml#/APIReference"
     - $ref: "./combined.yml#/ResourceDescription"

--- a/src/views/pages/openapidocs.ejs
+++ b/src/views/pages/openapidocs.ejs
@@ -53,7 +53,7 @@
       schema-description-expanded="false"
       bg-color="#171717"
       primary-color="#D81921"
-      text-color="#fff"
+      text-color="#bebebe"
       regular-font="IBM Plex Sans"
       mono-font="JetBrains Mono"
       theme="dark"


### PR DESCRIPTION
## What does this do?
This PR includes a number of changes to the openapi docs.
- tweak main text color 
- general organization: pull some params into their own files, move to standardize how reference objects are named, standardize model descriptions
- start standardizing field descriptions to more use declarative / active voice, for example:
 ```
description: "The starting equipment a character automatically gets."
  -->
description: "Starting equipment for all new characters of this background."
```

<hr>

- tweak formatting of model descriptions so they're more recognizable in schema descriptions

prod:
<img width="721" alt="Screen Shot 2022-03-24 at 8 27 53 PM" src="https://user-images.githubusercontent.com/1425775/160048684-73c0f96c-74f8-48a2-b2d5-6bdd8f1cbaa9.png">

localhost:
<img width="729" alt="Screen Shot 2022-03-24 at 8 27 24 PM" src="https://user-images.githubusercontent.com/1425775/160048732-2b3e6dbb-f134-4936-9743-e447d9350f1d.png">

## How was it tested?
localhost

## Is there a Github issue this is resolving?
no

## Was any impacted documentation updated to reflect this change?
yes :) 

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
