### PR TITLE
Switch to github container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Log in to the Container registry
+      -
+        name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
   repository_dispatch:
     types: [build_application]
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   unit:
     name: Run tests
@@ -39,6 +42,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run test:integration:local
   heroku:
     name: Trigger Heroku Deploy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   db:
-    image: bagelbits/5e-database:latest
+    image: ghcr.io/5e-bits/5e-database:latest
     ports:
       - "27017:27017"
 


### PR DESCRIPTION
## What does this do?

Switches us from dockerhub to github container store in the `docker-compose.yml`. Thanks to the work that @peshka did.

## How was it tested?

Running the CI

## Is there a Github issue this is resolving?

Nope.

## Was any impacted documentation updated to reflect this change?

I don't... think so?

## Here's a fun image for your troubles

![image](https://user-images.githubusercontent.com/353626/160069985-242690b5-c4ce-4149-b791-08c401202b62.png)

