### PR TITLE
ecshreve: [openapi] - small tweaks to bring docs in line with prod

### DIFF
--- a/src/controllers/api/classController.js
+++ b/src/controllers/api/classController.js
@@ -86,7 +86,11 @@ exports.showStartingEquipmentForClass = async (req, res, next) => {
 exports.showSpellcastingForClass = async (req, res, next) => {
   try {
     const data = await Class.findOne({ index: req.params.index });
-    return res.status(200).json(data.spellcasting);
+    if (data && data.spellcasting) {
+      return res.status(200).json(data.spellcasting);
+    } else {
+      return res.status(404).json({ error: 'Not found' });
+    }
   } catch (err) {
     next(err);
   }

--- a/src/swagger/README.md
+++ b/src/swagger/README.md
@@ -10,7 +10,7 @@ our OpenAPI definition, and [RapiDoc](https://mrin9.github.io/RapiDoc/index.html
 In it's current state our OpenAPI documentation is _almost_ an accurate representation of the actual behavior of the API. The first version of these new docs was made based on models and responses defined in the existing documentation. A number of small inconsistencies were discovered that have not been addressed.
 
 ### TODO
-- [ ] document query parameters
+- [x] document query parameters
 - [ ] standardize schema object naming (mostly cleanup the /schemas directory)
 - [ ] validate schemas against models or actual api responses
 - [ ] validate schema and field descriptions are accurate
@@ -18,6 +18,8 @@ In it's current state our OpenAPI documentation is _almost_ an accurate represen
 - [ ] add tag descriptions
 - [ ] add section in overview with summary of SRD / OGL
 - [ ] add troubleshooting section to overview
+- [ ] enumerate the `class.class_specific` field
+- [ ] give user option to change render style and schema style (rapidoc)
 
 ## Why OpenAPI?
 

--- a/src/swagger/parameters/path/classes.yml
+++ b/src/swagger/parameters/path/classes.yml
@@ -19,7 +19,7 @@ class-index:
       - sorcerer
       - warlock
       - wizard
-    example: barbarian
+    example: paladin
 class-level:
   name: class_level
   in: path

--- a/src/swagger/paths/ability-scores.yml
+++ b/src/swagger/paths/ability-scores.yml
@@ -3,10 +3,7 @@ get:
   description: |
     # Ability Score
 
-    Each of a creature’s abilities has a score, a number that defines the 
-    magnitude of that ability. An ability score is not just a measure of innate 
-    capabilities, but also encompasses a creature’s training and competence in 
-    activities related to that ability.
+    Represents one of the six abilities that describes a creature's physical and mental characteristics. The three main rolls of the game - the ability check, the saving throw, and the attack roll - rely on the ability scores. [[SRD p76](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf#page=76)]
   tags:
     - Character Data
   parameters:

--- a/src/swagger/paths/alignments.yml
+++ b/src/swagger/paths/alignments.yml
@@ -3,11 +3,7 @@ get:
   description: |
     # Alignment
 
-    A typical creature in the game world has an alignment, which broadly 
-    describes its moral and personal attitudes. Alignment is a combination of 
-    two factors: one identifies morality (good, evil, or neutral), and the other 
-    describes attitudes toward society and order (lawful, chaotic, or neutral). 
-    Thus, nine distinct alignments define the possible combinations.
+    A typical creature in the game world has an alignment, which broadly describes its moral and personal attitudes. Alignment is a combination of two factors: one identifies morality (good, evil, or neutral), and the other describes attitudes toward society and order (lawful, chaotic, or neutral). Thus, nine distinct alignments define the possible combinations.[[SRD p58](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf#page=58)]
   tags:
     - Character Data
   parameters:

--- a/src/swagger/paths/backgrounds.yml
+++ b/src/swagger/paths/backgrounds.yml
@@ -3,13 +3,11 @@ get:
   description: |
     # Background
 
-    Every story has a beginning. Your character’s background reveals where you 
-    came from, how you became an adventurer, and your place in the world. Your 
-    fighter might have been a courageous knight or a grizzled soldier. Your 
-    wizard could have been a sage or an artisan. Your rogue might have gotten 
-    by as a guild thief or commanded audiences as a jester."
+    Every story has a beginning. Your character's background reveals where you came from, how you became an adventurer, and your place in the world. Choosing a background provides you with important story cues about your character's identity. [[SRD p60](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf#page=60)]
+
+    _Note:_ acolyte is the only background included in the SRD.
   tags:
-    - Backgrounds
+    - Character Data
   parameters:
     - $ref: "../parameters/combined.yml#/background-index"
   responses:

--- a/src/swagger/paths/classes.yml
+++ b/src/swagger/paths/classes.yml
@@ -244,6 +244,14 @@ class-spellcasting-path:
                   desc:
                     - You can use a musical instrument (see Equipment) as a spellcasting focus for your
                       bard spells.
+      "404":
+        description: Not found.
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/combined.yml#/error-response"
+            example:
+              error: Not found
 
 # /api/classes/{index}/features
 class-features-path:

--- a/src/swagger/paths/classes.yml
+++ b/src/swagger/paths/classes.yml
@@ -8,7 +8,7 @@ class-path:
       A character class is a fundamental part of the identity and nature of 
       characters in the Dungeons & Dragons role-playing game. A character's 
       capabilities, strengths, and weaknesses are largely defined by its class. 
-      A character's class affects a character's available skills and abilities.
+      A character's class affects a character's available skills and abilities. [[SRD p8-55](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf#page=8)]
     tags:
       - Class
     parameters:
@@ -140,7 +140,7 @@ class-path:
 # /api/classes/{indexParam}/subclasses
 class-subclass-path:
   get:
-    summary: "Get subclasses available for a class."
+    summary: Get subclasses available for a class.
     tags:
       - Class Resource Lists
     parameters:
@@ -156,12 +156,12 @@ class-subclass-path:
               count: 1
               results:
                 - index: berserker
-                  name: "Berserker"
+                  name: Berserker
                   url: "/api/subclasses/berserker"
 #/api/classes/{indexParam}/spells
 class-spells-path:
   get:
-    summary: "Get spells available for a class."
+    summary: Get spells available for a class.
     tags:
       - Class Resource Lists
     parameters:
@@ -185,7 +185,7 @@ class-spells-path:
 # /api/classes/{index}/spellcasting
 class-spellcasting-path:
   get:
-    summary: "Get spellcasting info for a class."
+    summary: Get spellcasting info for a class.
     tags:
       - Class
     parameters:
@@ -248,14 +248,14 @@ class-spellcasting-path:
 # /api/classes/{index}/features
 class-features-path:
   get:
-    summary: "Get features available for a class."
+    summary: Get features available for a class.
     tags:
       - Class Resource Lists
     parameters:
       - $ref: "../parameters/combined.yml#/class-index"
     responses:
       "200":
-        description: "List of features for the class."
+        description: List of features for the class.
         content:
           application/json:
             schema:
@@ -263,14 +263,14 @@ class-features-path:
 # /api/classes/{index}/proficiencies
 class-proficiencies-path:
   get:
-    summary: "Get proficiencies available for a class."
+    summary: Get proficiencies available for a class.
     tags:
       - Class Resource Lists
     parameters:
       - $ref: "../parameters/combined.yml#/class-index"
     responses:
       "200":
-        description: "List of proficiencies for the class."
+        description: List of proficiencies for the class.
         content:
           application/json:
             schema:
@@ -278,7 +278,7 @@ class-proficiencies-path:
 # /api/classes/{index}/multi-classing:
 class-multi-classing-path:
   get:
-    summary: "Get multiclassing resource for a class."
+    summary: Get multiclassing resource for a class.
     tags:
       - Class
     parameters:
@@ -312,7 +312,7 @@ class-multi-classing-path:
 # /api/classes/{index}/levels
 class-levels-path:
   get:
-    summary: "Get all level resources for a class."
+    summary: Get all level resources for a class.
     tags:
       - Class Levels
     parameters:
@@ -329,7 +329,7 @@ class-levels-path:
 # /api/classes/{index}/levels/{class_level}
 class-level-path:
   get:
-    summary: "Get level resource for a class and level."
+    summary: Get level resource for a class and level.
     tags:
       - Class Levels
     parameters:
@@ -367,7 +367,7 @@ class-level-path:
 # /api/classes/{index}/levels/{class_level}/features:
 class-level-features-path:
   get:
-    summary: "Get features available to a class at the requested level."
+    summary: Get features available to a class at the requested level.
     tags:
       - Class Levels
     parameters:
@@ -392,7 +392,7 @@ class-level-features-path:
 # /api/classes/{index}/levels/{spell_level}/spells
 class-spell-level-spells-path:
   get:
-    summary: "Get spells of the requested level available to the class."
+    summary: Get spells of the requested level available to the class.
     tags:
       - Class Levels
     parameters:

--- a/src/swagger/paths/languages.yml
+++ b/src/swagger/paths/languages.yml
@@ -3,8 +3,7 @@ get:
   description: |
     # Language
 
-    By virtue of your race, your character can speak, read, and write 
-    certain languages.
+    Your race indicates the languages your character can speak by default, and your background might give you access to one or more additional languages of your choice. [[SRD p59](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf#page=59)]
   tags:
     - Character Data
   parameters:

--- a/src/swagger/paths/proficiencies.yml
+++ b/src/swagger/paths/proficiencies.yml
@@ -3,7 +3,7 @@ get:
   description: |
     # Proficiency 
 
-    By virtue of your race, your character can speak, read, and write certain Proficiencies.
+    By virtue of race, class, and background a character is proficient at using certain skills, weapons, and equipment. Characters can also gain additional proficiencies at higher levels or by multiclassing. A characters starting proficiencies are determined during character creation.
   tags:
     - Character Data
   parameters:

--- a/src/swagger/paths/skills.yml
+++ b/src/swagger/paths/skills.yml
@@ -3,10 +3,7 @@ get:
   description: |
     # Skill
 
-    Each ability covers a broad range of capabilities, including skills that a 
-    character or a monster can be proficient in. A skill represents a specific 
-    aspect of an ability score, and an individual’s proficiency in a skill 
-    demonstrates a focus on that aspect.
+    Each ability covers a broad range of capabilities, including skills that a character or a monster can be proficient in. A skill represents a specific aspect of an ability score, and an individual's proficiency in a skill demonstrates a focus on that aspect. [[SRD p77](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf#page=77)]
   tags:
     - Character Data
   parameters:
@@ -30,5 +27,4 @@ get:
               - Your Dexterity (Acrobatics) check covers your attempt to stay on your feet in a
                 tricky situation, such as when you're trying to run across a sheet of ice, balance
                 on a tightrope, or stay upright on a rocking ship's deck. The GM might also call
-                for a Dexterity (Acrobatics) check to see if you can perform acrobatic stunts, including
-                dives, rolls, somersaults, and flips.
+                for a Dexterity (Acrobatics) check to see if you can perform acrobatic stunts, including dives, rolls, somersaults, and flips.

--- a/src/swagger/schemas/alignments.yml
+++ b/src/swagger/schemas/alignments.yml
@@ -2,9 +2,11 @@ description: |
   `Alignment`
 allOf:
   - $ref: "./combined.yml#/APIReference"
-  - $ref: "./combined.yml#/ResourceDescription"
   - type: object
     properties:
+      desc:
+        description: Brief description of the resource.
+        type: string
       abbreviation:
         description: Abbreviation/initials/acronym for the alignment.
         type: string

--- a/src/swagger/schemas/backgrounds.yml
+++ b/src/swagger/schemas/backgrounds.yml
@@ -32,7 +32,9 @@ allOf:
             items:
               type: string
       personality_traits:
-        $ref: "./combined.yml#/Choice"
+        description: Choice of personality traits for this background.
+        type: object
+
       ideals:
         $ref: "./combined.yml#/Choice"
       bonds:

--- a/src/swagger/schemas/backgrounds.yml
+++ b/src/swagger/schemas/backgrounds.yml
@@ -1,43 +1,63 @@
-description: |
-  `Background`
-allOf:
-  - $ref: "./combined.yml#/APIReference"
-  - type: object
-    properties:
-      starting_proficiencies:
-        description: "Starting proficiencies for all new characters of this background."
-        type: array
-        items:
-          $ref: "./combined.yml#/APIReference"
-      starting_equipment:
-        description: "Starting equipment for all new characters of this background."
-        type: array
-        items:
-          $ref: "./combined.yml#/APIReference"
-      starting_equipment_options:
-        description: List of choices of starting equipment for all new characters of this background.
-        type: array
-        items:
+ideal-model:
+  type: object
+  properties:
+    desc:
+      type: string
+    alignments:
+      description: List of alignments associated with the ideal.
+      type: array
+      items:
+        $ref: "./combined.yml#/APIReference"
+background-model:
+  description: |
+    `Background`
+  allOf:
+    - $ref: "./combined.yml#/APIReference"
+    - type: object
+      properties:
+        starting_proficiencies:
+          description: "Starting proficiencies for all new characters of this background."
+          type: array
+          items:
+            $ref: "./combined.yml#/APIReference"
+        starting_equipment:
+          description: "Starting equipment for all new characters of this background."
+          type: array
+          items:
+            $ref: "./combined.yml#/APIReference"
+        starting_equipment_options:
+          description: List of choices of starting equipment for all new characters of this background.
+          type: array
+          items:
+            $ref: "./combined.yml#/Choice"
+        language_options:
           $ref: "./combined.yml#/Choice"
-      language_options:
-        $ref: "./combined.yml#/Choice"
-      feature:
-        description: Special feature granted to new characters of this background.
-        type: object
-        properties:
-          name:
-            type: string
-          desc:
-            type: array
-            items:
+        feature:
+          description: Special feature granted to new characters of this background.
+          type: object
+          properties:
+            name:
               type: string
-      personality_traits:
-        description: Choice of personality traits for this background.
-        type: object
+            desc:
+              type: array
+              items:
+                type: string
+        personality_traits:
+          description: Choice of personality traits for this background.
+          type: object
 
-      ideals:
-        $ref: "./combined.yml#/Choice"
-      bonds:
-        $ref: "./combined.yml#/Choice"
-      flaws:
-        $ref: "./combined.yml#/Choice"
+        ideals:
+          type: object
+          properties:
+            choose:
+              type: number
+            type:
+              type: string
+            from:
+              type: array
+              items:
+                $ref: "./combined.yml#/ideal"
+        bonds:
+          $ref: "./combined.yml#/string-choice"
+        flaws:
+          $ref: "./combined.yml#/string-choice"

--- a/src/swagger/schemas/classes.yml
+++ b/src/swagger/schemas/classes.yml
@@ -19,9 +19,20 @@ class-model:
           description: URL of the spell resource list for the class.
           type: string
         starting_equipment:
-          description: Choices of starting equipment.
-          allOf:
-            - $ref: "./combined.yml#/Choice"
+          description: List of equipment and their quantities all players of the class start with.
+          type: array
+          items:
+            type: object
+            properties:
+              quantity:
+                type: number
+              equipment:
+                $ref: "./combined.yml#/APIReference"
+        starting_equipment_options:
+          description: List of choices of starting equipment.
+          type: array
+          items:
+            $ref: "./combined.yml#/equipment-option"
         proficiency_choices:
           description: List of choices of starting proficiencies.
           type: array

--- a/src/swagger/schemas/combined.yml
+++ b/src/swagger/schemas/combined.yml
@@ -82,3 +82,5 @@ Monster:
   $ref: "./monsters.yml#/monster-model"
 SpellPrerequisite:
   $ref: "./subclass.yml#/spell-prerequisite"
+equipment-option:
+  $ref: "./equipment.yml#/equipment-option-model"

--- a/src/swagger/schemas/combined.yml
+++ b/src/swagger/schemas/combined.yml
@@ -49,7 +49,7 @@ Proficiency:
 Language:
   $ref: "./language.yml"
 Background:
-  $ref: "./backgrounds.yml"
+  $ref: "./backgrounds.yml#/background-model"
 Feat:
   $ref: "./feats.yml"
 Subclass:
@@ -84,3 +84,9 @@ SpellPrerequisite:
   $ref: "./subclass.yml#/spell-prerequisite"
 equipment-option:
   $ref: "./equipment.yml#/equipment-option-model"
+string-choice:
+  $ref: "./common.yml#/string-choice-model"
+ideal:
+  $ref: "./backgrounds.yml#/ideal-model"
+error-response:
+  $ref: "./common.yml#/error-response-model"

--- a/src/swagger/schemas/common.yml
+++ b/src/swagger/schemas/common.yml
@@ -40,6 +40,22 @@ choice-model:
       type: array
       items:
         $ref: "./combined.yml#/APIReference"
+string-choice-model:
+  description: |
+    `String Choice`
+  type: object
+  properties:
+    choose:
+      description: "Number of items to pick from the list."
+      type: number
+    type:
+      description: "Type of resource to choose from."
+      type: string
+    from:
+      description: "List of descriptions to choose from."
+      type: array
+      items:
+        type: string
 cost-model:
   description: |
     `Cost`
@@ -79,3 +95,10 @@ resource-description-model:
       type: array
       items:
         type: string
+error-response-model:
+  type: object
+  properties:
+    error:
+      type: string
+  required:
+    - error

--- a/src/swagger/schemas/equipment.yml
+++ b/src/swagger/schemas/equipment.yml
@@ -1,7 +1,7 @@
 equipment-model:
   description: |
     `Equipment`
-  oneOf:
+  anyOf:
     - $ref: "./combined.yml#/Weapon"
     - $ref: "./combined.yml#/Armor"
     - $ref: "./combined.yml#/Gear"
@@ -63,3 +63,31 @@ magic-item-model:
       properties:
         equipment_category:
           $ref: "./combined.yml#/APIReference"
+equipment-option-model:
+  type: object
+  properties:
+    choose:
+      type: number
+    type:
+      type: string
+    from:
+      type: array
+      items:
+        anyOf:
+          - type: object
+            properties:
+              quantity:
+                type: number
+              equipment:
+                $ref: "./combined.yml#/APIReference"
+          - type: object
+            properties:
+              choose:
+                type: number
+              type:
+                type: string
+              from:
+                type: object
+                properties:
+                  equipment_category:
+                    $ref: "./combined.yml#/APIReference"

--- a/src/swagger/schemas/language.yml
+++ b/src/swagger/schemas/language.yml
@@ -9,7 +9,7 @@ allOf:
         type: string
       type:
         type: string
-        enum: [standard, exotic]
+        enum: [Standard, Exotic]
       script:
         description: "Script used for writing in the language."
         type: string

--- a/src/swagger/swagger.yml
+++ b/src/swagger/swagger.yml
@@ -103,6 +103,23 @@ info:
     }
     ```
 
+    ## FAQ
+
+    ### What is the SRD?
+    The SRD, or Systems Reference Document, contains guidelines for publishing content under the OGL. This allows for some of the data for D&D 5e to be open source. The API only covers data that can be found in the SRD. [Here's a link to the full text of the SRD.](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf)
+
+    ### What is the OGL?
+    The Open Game License (OGL) is a public copyright license by Wizards of the Coast that may be used by tabletop role-playing game developers to grant permission to modify, copy, and redistribute some of the content designed for their games, notably game mechanics. However, they must share-alike copies and derivative works. [More information about the OGL can be found here.](https://en.wikipedia.org/wiki/Open_Game_License)
+
+    ### A monster, spell, subclass, etc. is missing from the API / Database. Can I add it?
+    Please check if the data is within the SRD. If it is, feel free to open an issue or PR to add it yourself. Otherwise, due to legal reasons, we cannot add it.
+
+    ### Can this API be self hosted?
+    Yes it can! You can also host the data yourself if you don't want to use the API at all. You can also make changes and add extra data if you like. However, it is up to you to merge in new changes to the data and API. 
+
+    #### Can I publish is on <insert platform>? Is this free use?
+    Yes, you can. The API itself is under the [MIT license](https://opensource.org/licenses/MIT), and the underlying data accessible via the API is supported under the SRD and OGL.
+
     # Status Page
 
     The status page for the API can be found here: https://5e-bits.github.io/dnd-uptime/
@@ -139,16 +156,6 @@ servers:
 tags:
   - name: Common
   - name: Character Data
-    description: |
-      ### `AbilityScore`
-      Represents one of the six abilities that describes a creature's	physical and mental characteristics. The three	main	rolls	of the game - the	ability	check, the saving	throw,	and	the	attack roll - rely on the ability scores. [[SRD p75](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf#page=76)]
-
-      - Strength,	measuring	physical power
-      - Dexterity, measuring	agility
-      - Constitution,	measuring	endurance
-      - Intelligence,	measuring	reasoning	and	memory
-      - Wisdom,	measuring	perception and	insight
-      - Charisma,	measuring	force	of personality
 
 paths:
   /api:


### PR DESCRIPTION
## What does this do?
- Small tweaks to  schemas to align them with actual behavior. 
- Also makes a change to one controller to properly check and return a `404` if a `classLevel` doesn't have a `spellcasting` attribute.

## How was it tested?
- localhost
- generated postman test collection from the `openapi.json`  and used it and validated that changes resolved the test failures related to the response body not matching the schema in the documentation

## Is there a Github issue this is resolving?
no

## Was any impacted documentation updated to reflect this change?
no

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
