### PR TITLE
ecshreve: [bug] - fix schema field definition for class level

### DIFF
--- a/src/models/level/index.js
+++ b/src/models/level/index.js
@@ -28,7 +28,10 @@ const ClassSpecific = new Schema({
   bardic_inspiration_die: { type: Number, index: true },
   brutal_critical_dice: { type: Number, index: true },
   channel_divinity_charges: { type: Number, index: true },
-  creating_spell_slots: [ClassSpecificCreatingSpellSlot],
+  creating_spell_slots: {
+    type: [ClassSpecificCreatingSpellSlot],
+    default: undefined,
+  },
   destroy_undead_cr: { type: Number, index: true },
   extra_attacks: { type: Number, index: true },
   favored_enemies: { type: Number, index: true },

--- a/src/swagger/paths/classes.yml
+++ b/src/swagger/paths/classes.yml
@@ -362,7 +362,6 @@ class-level-path:
                   name: Unarmored Defense
                   url: "/api/features/barbarian-unarmored-defense"
               class_specific:
-                creating_spell_slots: []
                 rage_count: 2
                 rage_damage_bonus: 2
                 brutal_critical_dice: 0


### PR DESCRIPTION
## What does this do?
The creating_spell_slots field is an array of subdocuments, and
in mongoose arrays implicitly have a default value of []. This was
causing this field to be included in the response for every resource
from this endpoint regardless of class.

Explicitly setting default: undefined fixes this.

see the "Arrays" section under "SchemaType Options": https://mongoosejs.com/docs/schematypes.html#schematype-options

## How was it tested?
localhost

## Is there a Github issue this is resolving?
no

## Was any impacted documentation updated to reflect this change?
fixing the documentation for this endpoint was how i found this bug :)

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
