### PR TITLE
ecshreve: [docs] - last few changes to bring docs schema in line with reality

### DIFF
--- a/src/swagger/parameters/query/monsters.yml
+++ b/src/swagger/parameters/query/monsters.yml
@@ -9,8 +9,8 @@ challenge-rating-filter:
       type: number
   examples:
     single-value:
-      value: 1
+      value: [1]
     multiple-value:
-      value: 1,2
+      value: [1,2]
     multiple-value-with-float:
-      value: 2,0.25
+      value: [2,0.25]

--- a/src/swagger/parameters/query/spells.yml
+++ b/src/swagger/parameters/query/spells.yml
@@ -9,9 +9,9 @@ level-filter:
       type: integer
   examples:
     single-value:
-      value: 1
+      value: [1]
     multiple-value:
-      value: 1,2
+      value: [1,2]
 school-filter:
   name: school
   in: query
@@ -23,8 +23,8 @@ school-filter:
       type: string
   examples:
     single-value:
-      value: illusion
+      value: [illusion]
     multiple-value:
-      value: evocation,illusion
+      value: [evocation,illusion]
     partial-value:
-      value: illu
+      value: [illu]

--- a/src/swagger/paths/subclasses.yml
+++ b/src/swagger/paths/subclasses.yml
@@ -166,9 +166,10 @@ subclass-level-path:
         in: path
         required: true
         schema:
-          type: number
+          type: integer
           minimum: 1
           maximum: 20
+        example: 6
     responses:
       "200":
         description: "Level resource for the subclass and level."
@@ -204,9 +205,10 @@ subclass-level-features-path:
         in: path
         required: true
         schema:
-          type: number
+          type: integer
           minimum: 0
           maximum: 20
+        example: 6
     responses:
       "200":
         description: "List of features for the subclass and level."

--- a/src/swagger/schemas/classes.yml
+++ b/src/swagger/schemas/classes.yml
@@ -1,3 +1,135 @@
+# TODO: add descriptions to these class-specific fields.
+cs-barbarian:
+  description: Barbarian Class Specific Features
+  type: object
+  properties:
+    rage_count:
+      type: number
+    rage_damage_bonus:
+      type: number
+    brutal_critical_dice:
+      type: number
+cs-bard:
+  description: Bard Class Specific Features
+  type: object
+  properties:
+    bardic_inspiration_dice:
+      type: number
+    song_of_rest_die:
+      type: number
+    magical_secrets_max_5:
+      type: number
+    magical_secrets_max_7:
+      type: number
+    magical_secrets_max_9:
+      type: number
+cs-cleric:
+  description: Cleric Class Specific Features
+  type: object
+  properties:
+    channel_divinity_charges:
+      type: number
+    destroy_undead_cr:
+      type: number
+cs-druid:
+  description: Druid Class Specific Features
+  type: object
+  properties:
+    wild_shape_max_cr:
+      type: number
+    wild_shape_swim:
+      type: boolean
+    wild_shape_fly:
+      type: boolean
+cs-fighter:
+  description: Fighter Class Specific Features
+  type: object
+  properties:
+    action_surges:
+      type: number
+    indomitable_uses:
+      type: number
+    extra_attacks:
+      type: number
+cs-monk:
+  description: Monk Class Specific Features
+  type: object
+  properties:
+    ki_points:
+      type: number
+    unarmored_movement:
+      type: number
+    martial_arts:
+      type: object
+      properties:
+        dice_count:
+          type: number
+        dice_value:
+          type: number
+cs-paladin:
+  description: Paladin Class Specific Features
+  type: object
+  properties:
+    aura_range:
+      type: number
+cs-ranger:
+  description: Bard Ranger Specific Features
+  type: object
+  properties:
+    favored_enemies:
+      type: number
+    favored_terrain:
+      type: number
+cs-rogue:
+  description: Bard Rogue Specific Features
+  type: object
+  properties:
+    sneak_attack:
+      type: object
+      properties:
+        dice_count:
+          type: number
+        dice_value:
+          type: number
+cs-sorcerer:
+  description: Bard Sorcerer Specific Features
+  type: object
+  properties:
+    sorcery_points:
+      type: number
+    metamagic_known:
+      type: number
+    creating_spell_slots:
+      type: array
+      items:
+        type: object
+        properties:
+          spell_slot_level:
+            type: number
+          sorcery_point_cost:
+            type: number
+cs-warlock:
+  description: Bard Warlock Specific Features
+  type: object
+  properties:
+    invocations_known:
+      type: number
+    mystic_arcanum_level_6:
+      type: number
+    mystic_arcanum_level_7:
+      type: number
+    mystic_arcanum_level_8:
+      type: number
+    mystic_arcanum_level_9:
+      type: number
+cs-wizard:
+  description: Wizard Class Specific Features
+  type: object
+  properties:
+    arcane_recover_levels:
+      type: number
+  
+
 class-model:
   description: |
     `Class`
@@ -106,4 +238,16 @@ class-level-model:
           type: number
     class_specific:
       description: "Class specific information such as dice values for bard songs and number of warlock invocations."
-      additionalProperties: {}
+      anyOf:
+        - $ref: "#/cs-barbarian"
+        - $ref: "#/cs-bard"
+        - $ref: "#/cs-cleric"
+        - $ref: "#/cs-druid"
+        - $ref: "#/cs-fighter"
+        - $ref: "#/cs-monk"
+        - $ref: "#/cs-paladin"
+        - $ref: "#/cs-ranger"
+        - $ref: "#/cs-rogue"
+        - $ref: "#/cs-sorcerer"
+        - $ref: "#/cs-warlock"
+        - $ref: "#/cs-wizard"

--- a/src/swagger/schemas/monsters.yml
+++ b/src/swagger/schemas/monsters.yml
@@ -270,9 +270,7 @@ monster-model:
             $ref: "./combined.yml#/APIReference"
         languages:
           description: "The languages a monster is able to speak."
-          type: array
-          items:
-            type: string
+          type: string
         proficiencies:
           description: "A list of proficiencies of a monster."
           type: array

--- a/src/swagger/schemas/rules.yml
+++ b/src/swagger/schemas/rules.yml
@@ -3,9 +3,11 @@ rule-model:
     `Rule`
   allOf:
     - $ref: "./combined.yml#/APIReference"
-    - $ref: "./combined.yml#/ResourceDescription"
     - type: object
       properties:
+        desc:
+          description: Description of the rule.
+          type: string
         subsections:
           description: "List of sections for each subheading underneath the rule in the SRD."
           type: array
@@ -16,4 +18,8 @@ rule-section-model:
     `RuleSection`
   allOf:
     - $ref: "./combined.yml#/APIReference"
-    - $ref: "./combined.yml#/ResourceDescription"
+    - type: object
+      properties:
+        desc:
+          description: Description of the rule.
+          type: string

--- a/src/swagger/schemas/subrace.yml
+++ b/src/swagger/schemas/subrace.yml
@@ -2,12 +2,15 @@ description: |
   `Subrace`
 allOf:
   - $ref: "./combined.yml#/APIReference"
-  - $ref: "./combined.yml#/ResourceDescription"
   - type: object
     properties:
+      desc:
+          description: Description of the subrace.
+          type: string
       race:
         description: "Parent race for the subrace."
-        type: number
+        allOf:
+          - $ref: "./combined.yml#/APIReference"
       ability_bonuses:
         description: "Additional ability bonuses for the subrace."
         type: array


### PR DESCRIPTION
## What does this do?
Worked with a generated postman collection locally to verify the response schemas in the docs matched the schema of what was actually returned from the api. This process uncovered a number of small inconsistencies, this PR fixes those.

## How was it tested?
localhost

## Is there a Github issue this is resolving?
no

## Was any impacted documentation updated to reflect this change?
these are docs

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
