### PR TITLE
feat(magic-item): update schema for magic items

### DIFF
--- a/src/models/magicItem/index.js
+++ b/src/models/magicItem/index.js
@@ -16,6 +16,7 @@ const MagicItem = new Schema({
   rarity: Rarity,
   url: { type: String, index: true },
   variants: [APIReference],
+  variant: Boolean,
 });
 
 module.exports = mongoose.model('MagicItem', MagicItem, 'magic-items');

--- a/src/models/magicItem/index.js
+++ b/src/models/magicItem/index.js
@@ -2,13 +2,20 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 const { APIReference } = require('../common');
 
+const Rarity = new Schema({
+  _id: false,
+  name: { type: String, index: true },
+});
+
 const MagicItem = new Schema({
   _id: { type: String, select: false },
   desc: { type: [String], index: true },
   equipment_category: APIReference,
   index: { type: String, index: true },
   name: { type: String, index: true },
+  rarity: Rarity,
   url: { type: String, index: true },
+  variants: [APIReference],
 });
 
 module.exports = mongoose.model('MagicItem', MagicItem, 'magic-items');

--- a/src/models/magicItem/types.d.ts
+++ b/src/models/magicItem/types.d.ts
@@ -1,11 +1,18 @@
 import * as mongoose from 'mongoose';
 import { APIReference } from '../common/types';
 
+interface Rarity {
+  _id?: mongoose.Types.ObjectId;
+  name: string;
+}
+
 export type MagicItem = {
   _id?: mongoose.Types.ObjectId;
   desc: string[];
   equipment_category: APIReference;
   index: string;
   name: string;
+  rarity: Rarity;
   url: string;
+  variants: APIReference[];
 };

--- a/src/models/magicItem/types.d.ts
+++ b/src/models/magicItem/types.d.ts
@@ -15,4 +15,5 @@ export type MagicItem = {
   rarity: Rarity;
   url: string;
   variants: APIReference[];
+  variant: boolean;
 };

--- a/src/swagger/paths/magic-items.yml
+++ b/src/swagger/paths/magic-items.yml
@@ -34,3 +34,6 @@ get:
               index: armor
               name: Armor
               url: "/api/equipment-categories/armor"
+            rarity:
+              name: Uncommon
+            variants: []

--- a/src/swagger/paths/magic-items.yml
+++ b/src/swagger/paths/magic-items.yml
@@ -37,3 +37,4 @@ get:
             rarity:
               name: Uncommon
             variants: []
+            variant: false

--- a/src/swagger/schemas/equipment.yml
+++ b/src/swagger/schemas/equipment.yml
@@ -59,10 +59,29 @@ magic-item-model:
     `MagicItem`
   allOf:
     - $ref: "./combined.yml#/APIReference"
+    - $ref: "./combined.yml#/ResourceDescription"
     - type: object
       properties:
         equipment_category:
           $ref: "./combined.yml#/APIReference"
+        rarity:
+          type: object
+          properties:
+            name:
+              description: "The rarity of the item."
+              type: string
+              enum:
+                - Varies
+                - Common
+                - Uncommon
+                - Rare
+                - Very Rare
+                - Legendary
+                - Artifact
+        variants:
+          type: array
+          items:
+            $ref: "./combined.yml#/APIReference"
 equipment-option-model:
   type: object
   properties:

--- a/src/swagger/schemas/equipment.yml
+++ b/src/swagger/schemas/equipment.yml
@@ -82,6 +82,9 @@ magic-item-model:
           type: array
           items:
             $ref: "./combined.yml#/APIReference"
+        variant:
+          description: "Whether this is a variant or not"
+          type: boolean
 equipment-option-model:
   type: object
   properties:


### PR DESCRIPTION
## What does this do?

adds rarity and variants to magic items

## How was it tested?

Loaded up data from 5e-bits/5e-database#455 and verified documentation from OpenAPI and GraphQL looked correct

## Is there a Github issue this is resolving?

5e-bits/5e-database#455

## Was any impacted documentation updated to reflect this change?

Yes, magic items

## Here's a fun image for your troubles

![glowing mushrooms](https://images.unsplash.com/photo-1499343162160-cd1441923dd3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2670&q=80)
