### PR TITLE
feat(levels):  Add  `subclass` query and drop subclasses from normal request

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/node_modules/
+dist

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bundle-swagger": "npm run validate-swagger && swagger-cli bundle --outfile src/swagger/dist/openapi.yml --type yaml src/swagger/swagger.yml && swagger-cli bundle --outfile src/swagger/dist/openapi.json --type json src/swagger/swagger.yml",
     "test": "npm run test:unit && npm run test:integration:local",
     "test:unit": "jest -c jest.config.unit.ts",
-    "test:integration": "jest -c jest.config.integration.ts --runInBand --detectOpenHandles --forceExit",
+    "test:integration": "jest -c jest.config.integration.ts --detectOpenHandles --forceExit",
     "test:integration:local": "docker-compose pull && docker-compose build && docker-compose run --use-aliases api npm run test:integration"
   },
   "dependencies": {

--- a/src/swagger/parameters/combined.yml
+++ b/src/swagger/parameters/combined.yml
@@ -50,5 +50,7 @@ school-filter:
   $ref: "./query/spells.yml#/school-filter"
 challenge-rating-filter:
   $ref: "./query/monsters.yml#/challenge-rating-filter"
+levels-subclass-filter:
+  $ref: "./query/classes.yml#/levels-subclass-filter"
 base-endpoint-index:
   $ref: "./path/common.yml"

--- a/src/swagger/parameters/query/classes.yml
+++ b/src/swagger/parameters/query/classes.yml
@@ -1,0 +1,12 @@
+levels-subclass-filter:
+  name: subclass
+  in: query
+  required: false
+  description: Adds subclasses for class to the response
+  schema:
+    type: string
+  examples:
+    single-value:
+      value: berserker
+    partial-value:
+      value: ber

--- a/src/swagger/paths/classes.yml
+++ b/src/swagger/paths/classes.yml
@@ -3,11 +3,11 @@ class-path:
   get:
     summary: Get a class by index.
     description: |
-      # Class 
+      # Class
 
-      A character class is a fundamental part of the identity and nature of 
-      characters in the Dungeons & Dragons role-playing game. A character's 
-      capabilities, strengths, and weaknesses are largely defined by its class. 
+      A character class is a fundamental part of the identity and nature of
+      characters in the Dungeons & Dragons role-playing game. A character's
+      capabilities, strengths, and weaknesses are largely defined by its class.
       A character's class affects a character's available skills and abilities. [[SRD p8-55](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf#page=8)]
     tags:
       - Class
@@ -325,6 +325,7 @@ class-levels-path:
       - Class Levels
     parameters:
       - $ref: "../parameters/combined.yml#/class-index"
+      - $ref: "../parameters/combined.yml#/challenge-rating-filter"
     responses:
       "200":
         description: OK

--- a/src/tests/controllers/api/classController.test.js
+++ b/src/tests/controllers/api/classController.test.js
@@ -120,7 +120,7 @@ describe('showLevelsForClass', () => {
       url: '/api/classes/barbarian/level/3',
     },
   ];
-  const request = mockRequest({ params: { index: 'barbarian' } });
+  const request = mockRequest({ query: {}, params: { index: 'barbarian' } });
 
   it('returns a list of objects', async () => {
     mockingoose(Level).toReturn(findDoc, 'find');
@@ -135,7 +135,7 @@ describe('showLevelsForClass', () => {
         mockingoose(Level).toReturn(null, 'findOne');
 
         const invalidShowParams = { index: 'test' };
-        const invalidRequest = mockRequest({ params: invalidShowParams });
+        const invalidRequest = mockRequest({ query: {}, params: invalidShowParams });
         await ClassController.showLevelsForClass(invalidRequest, response, mockNext);
 
         expect(response.status).toHaveBeenCalledWith(404);

--- a/src/tests/integration/api/classes.itest.ts
+++ b/src/tests/integration/api/classes.itest.ts
@@ -135,6 +135,17 @@ describe('/api/classes', () => {
         const res = await request(app).get(`/api/classes/${index}/levels`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.length).not.toEqual(0);
+        expect(res.body.length).toEqual(20);
+      });
+
+      it('returns the subclass levels as well', async () => {
+        const indexRes = await request(app).get('/api/classes');
+        const index = indexRes.body.results[1].index;
+        const subclass = indexRes.body.results[1].subclasses[0].index;
+        const res = await request(app).get(`/api/classes/${index}/levels?subclass=${subclass}`);
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.length).not.toEqual(0);
+        expect(res.body.length).toBeGreaterThan(20);
       });
 
       describe('/api/classes/:index/levels/:level', () => {

--- a/src/tests/integration/api/classes.itest.ts
+++ b/src/tests/integration/api/classes.itest.ts
@@ -142,7 +142,7 @@ describe('/api/classes', () => {
         const indexRes = await request(app).get('/api/classes');
         const index = indexRes.body.results[1].index;
         const classRes = await request(app).get(`/api/classes/${index}`);
-        const subclass = classRes.body.results[1].subclasses[0].index;
+        const subclass = classRes.body.subclasses[0].index;
         const res = await request(app).get(`/api/classes/${index}/levels?subclass=${subclass}`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.length).not.toEqual(0);

--- a/src/tests/integration/api/classes.itest.ts
+++ b/src/tests/integration/api/classes.itest.ts
@@ -141,7 +141,8 @@ describe('/api/classes', () => {
       it('returns the subclass levels as well', async () => {
         const indexRes = await request(app).get('/api/classes');
         const index = indexRes.body.results[1].index;
-        const subclass = indexRes.body.results[1].subclasses[0].index;
+        const classRes = await request(app).get(`/api/classes/${index}`);
+        const subclass = classRes.body.results[1].subclasses[0].index;
         const res = await request(app).get(`/api/classes/${index}/levels?subclass=${subclass}`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.length).not.toEqual(0);


### PR DESCRIPTION
## What does this do?
- [x] `/api/classes/:index/levels` will now only show the levels for the class and not include all subclasses.
- [x] The `subclass` query parameter has now been added, which will give you the levels for the class plus the levels for the subclass
- [x] Updated integration tests
- [x] Updated docs

## How was it tested?

Locally

## Is there a Github issue this is resolving?

This has been raised a few times in Discord and I'm finally fixing it.

## Was any impacted documentation updated to reflect this change?

Yup!

## Here's a fun image for your troubles

![image](https://user-images.githubusercontent.com/353626/161317710-708dd096-89a7-45a7-834e-277e1b2c332a.png)

