### PR TITLE
fix(docs): Wrong parameter

### DIFF
--- a/src/swagger/paths/classes.yml
+++ b/src/swagger/paths/classes.yml
@@ -325,7 +325,7 @@ class-levels-path:
       - Class Levels
     parameters:
       - $ref: "../parameters/combined.yml#/class-index"
-      - $ref: "../parameters/combined.yml#/challenge-rating-filter"
+      - $ref: "../parameters/combined.yml#/levels-subclass-filter"
     responses:
       "200":
         description: OK


### PR DESCRIPTION
## What does this do?

I used the wrong parameter in the  docs.

## How was it tested?

I haven't figured out how to test this correctly yet.

## Is there a Github issue this is resolving?

Not yet.

## Was any impacted documentation updated to reflect this change?

Yes but well... you get it.

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
