### PR TITLE
fix(mongoose): Marking some more fields defaults as `undefined`

### DIFF
--- a/src/models/class/index.js
+++ b/src/models/class/index.js
@@ -56,10 +56,10 @@ const MultiClassingPrereqOptions = new Schema({
 
 const MultiClassing = new Schema({
   _id: false,
-  prerequisites: [MultiClassingPrereq],
-  prerequisite_options: MultiClassingPrereqOptions,
-  proficiencies: [APIReference],
-  proficiency_choices: [ProficiencyChoice],
+  prerequisites: { type: [MultiClassingPrereq], default: undefined },
+  prerequisite_options: { type: MultiClassingPrereqOptions, default: undefined },
+  proficiencies: { type: [APIReference], default: undefined },
+  proficiency_choices: { type: [ProficiencyChoice], default: undefined },
 });
 
 const Class = new Schema({

--- a/src/models/monster/index.js
+++ b/src/models/monster/index.js
@@ -54,12 +54,12 @@ const Action = new Schema({
   name: { type: String, index: true },
   desc: { type: String, index: true },
   attack_bonus: { type: Number, index: true },
-  damage: [ActionDamage],
+  damage: { type: [ActionDamage], default: undefined },
   dc: ActionDC,
   options: ActionOptions,
   usage: ActionUsage,
   attack_options: ActionAttackOptions,
-  attacks: [ActionAttack],
+  attacks: { type: [ActionAttack], default: undefined },
 });
 
 const LegendaryAction = new Schema({
@@ -67,7 +67,7 @@ const LegendaryAction = new Schema({
   name: { type: String, index: true },
   desc: { type: String, index: true },
   attack_bonus: { type: Number, index: true },
-  damage: [ActionDamage],
+  damage: { type: [ActionDamage], default: undefined },
   dc: ActionDC,
 });
 
@@ -127,7 +127,7 @@ const SpecialAbility = new Schema({
   name: { type: String, index: true },
   desc: { type: String, index: true },
   attack_bonus: { type: Number, index: true },
-  damage: [ActionDamage],
+  damage: { type: [ActionDamage], default: undefined },
   dc: ActionDC,
   spellcasting: SpecialAbilitySpellcasting,
   usage: SpecialAbilityUsage,
@@ -156,7 +156,7 @@ const Monster = new Schema({
   damage_resistances: { type: [String], index: true },
   damage_vulnerabilities: { type: [String], index: true },
   dexterity: { type: Number, index: true },
-  forms: [APIReference],
+  forms: { type: [APIReference], default: undefined },
   hit_dice: { type: String, index: true },
   hit_points: { type: Number, index: true },
   index: { type: String, index: true },
@@ -165,7 +165,7 @@ const Monster = new Schema({
   legendary_actions: [LegendaryAction],
   name: { type: String, index: true },
   proficiencies: [Proficiency],
-  reactions: [Reaction],
+  reactions: { type: [Reaction], default: undefined },
   senses: Sense,
   size: { type: String, index: true },
   special_abilities: [SpecialAbility],


### PR DESCRIPTION
## What does this do?

This came up during #248. We sometimes get empty arrays in the response that don't actually exist in the data. I'm  cleaning up some of the remaining ones. Thanks to @ecshreve for pointing out how to do this.

## How was it tested?

Locally. After deleting all other docker containers and rebuilding  from scratch.

## Is there a Github issue this is resolving?

Not exactly. Just a running tally.

## Was any impacted documentation updated to reflect this change?

Nope.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
