### PR TITLE
fix(release): Tags should use version now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v2
+        with:
           fetch-depth: 0
       - name: Semantic Release
         id: semantic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,8 @@
 name: 5e SRD API CI/CD
 
 on:
-  create:
-    tags:
-      - 'v*'
   push:
     branches: [main]
-    tags:
-      - 'v*'
   pull_request:
     branches: [main]
   repository_dispatch:
@@ -65,25 +60,24 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy]
     if: github.event_name != 'pull_request'
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.steps.semantic.outputs.new_release_published}}
+      version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
-      - name: Checkout
+      - name: Checkout latest code
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 'lts/*'
-      - name: Install dependencies
-        run: npm install
-      - name: Release
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
   container-release:
     name: Container Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'create'
+    if: github.event_name != 'pull_request'
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
@@ -99,20 +93,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.github-release.outputs.version }}
+          labels:
+            version=${{ needs.github-release.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,8 @@ jobs:
   container-release:
     name: Container Release
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    needs: [github-release]
+    if: ${{needs.github-release.outputs.new_release_published}} == 'true'
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
       - name: Semantic Release
         id: semantic


### PR DESCRIPTION
## What does this do?

Previously we were tagging our containers as `main` instead of the version

## How was it tested?

Built on a separate repo

## Is there a Github issue this is resolving?

None yet

## Was any impacted documentation updated to reflect this change?

Nope

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
