### PR TITLE
ci(pr): Add PR linting workflow

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this do?

Since the Semantic Pull Requests app seems to have stopped working, I'm putting in a CI step instead.

## How was it tested?

I'm using it else where.

## Is there a Github issue this is resolving?

No. But it will keep me from merging PRs that break semantic release.

## Did you update the docs in the API? Please link an associated PR if applicable.

Not necessary.

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
