### PR TITLE
fix(params): Query params should not crash the server

### DIFF
--- a/src/controllers/api/monsterController.js
+++ b/src/controllers/api/monsterController.js
@@ -7,7 +7,7 @@ exports.index = async (req, res, next) => {
     searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
   }
   if (req.query.challenge_rating !== undefined) {
-    searchQueries.challenge_rating = { $in: req.query.challenge_rating.split(',') };
+    searchQueries.challenge_rating = { $in: req.query.challenge_rating };
   }
 
   const redisKey = req.originalUrl;

--- a/src/controllers/api/spellController.js
+++ b/src/controllers/api/spellController.js
@@ -8,11 +8,11 @@ exports.index = async (req, res, next) => {
   }
 
   if (req.query.level !== undefined) {
-    searchQueries.level = { $in: req.query.level.split(',') };
+    searchQueries.level = { $in: req.query.level };
   }
 
   if (req.query.school !== undefined) {
-    const schoolRegex = req.query.school.split(',').map(c => new RegExp(escapeRegExp(c), 'i'));
+    const schoolRegex = req.query.school.map(c => new RegExp(escapeRegExp(c), 'i'));
     searchQueries['school.name'] = { $in: schoolRegex };
   }
 

--- a/src/tests/integration/api/monsters.itest.ts
+++ b/src/tests/integration/api/monsters.itest.ts
@@ -82,7 +82,9 @@ describe('/api/monsters', () => {
         const cr20Res = await request(app).get(`/api/monsters?challenge_rating=${cr20}`);
         expect(cr20Res.statusCode).toEqual(200);
 
-        const bothRes = await request(app).get(`/api/monsters?challenge_rating=${cr1},${cr20}`);
+        const bothRes = await request(app).get(
+          `/api/monsters?challenge_rating=${cr1}&challenge_rating=${cr20}`
+        );
         expect(bothRes.statusCode).toEqual(200);
         expect(bothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
 

--- a/src/tests/integration/api/spells.itest.ts
+++ b/src/tests/integration/api/spells.itest.ts
@@ -81,7 +81,7 @@ describe('/api/spells', () => {
         expect(res2.statusCode).toEqual(200);
 
         const bothRes = await request(app).get(
-          `/api/spells?level=${expectedLevel1},${expectLevel2}`
+          `/api/spells?level=${expectedLevel1}&level=${expectLevel2}`
         );
         expect(bothRes.statusCode).toEqual(200);
         expect(bothRes.body.count).toEqual(res1.body.count + res2.body.count);
@@ -123,7 +123,7 @@ describe('/api/spells', () => {
         expect(res2.statusCode).toEqual(200);
 
         const bothRes = await request(app).get(
-          `/api/spells?school=${expectedSchool1},${expectedSchool2}`
+          `/api/spells?school=${expectedSchool1}&school=${expectedSchool2}`
         );
         expect(bothRes.statusCode).toEqual(200);
         expect(bothRes.body.count).toEqual(res1.body.count + res2.body.count);


### PR DESCRIPTION
## What does this do?

Apparently, Express actually handles lists correctly and I've been doing it wrong this whole time. And this was causing the server to crash because the docs know what they're doing but I don't.

## How was it tested?

Adjusted tests

## Is there a Github issue this is resolving?

Brought up in Discord

## Was any impacted documentation updated to reflect this change?

Nope. Now reality matches the docs.

## Here's a fun image for your troubles

![image](https://user-images.githubusercontent.com/353626/179554350-75c101ce-6772-4267-8aa3-a9b180f8ae46.png)
