### PR TITLE
fix(api): levels should not show up in api root

### DIFF
--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -9,6 +9,8 @@ exports.index = async (req, res, next) => {
 
     const apiIndex = {};
     data.forEach(item => {
+      if (item.index === 'levels') return;
+
       apiIndex[item.index] = `/api/${item.index}`;
     });
 

--- a/src/tests/integration/server.itest.ts
+++ b/src/tests/integration/server.itest.ts
@@ -46,5 +46,6 @@ describe('/api', () => {
     const res = await request(app).get('/api');
     expect(res.statusCode).toEqual(200);
     expect(res.body).toHaveProperty('ability-scores');
+    expect(res.body).not.toHaveProperty('levels');
   });
 });


### PR DESCRIPTION
## What does this do?

I forgot to clear out this from the automatic `/api` endpoint.

## How was it tested?

Adjusted tests accordingly.

## Is there a Github issue this is resolving?
This resolves #304 

## Was any impacted documentation updated to reflect this change?

None.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
