### PR TITLE
ci: Only deploy for main repo and not forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     name: Trigger Heroku Deploy
     runs-on: ubuntu-latest
     needs: [unit, integration, lint]
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == '5e-bits/5e-srd-api' }}
     steps:
       - uses: actions/checkout@v2
       - uses: akhileshns/heroku-deploy@v3.12.12
@@ -59,7 +59,7 @@ jobs:
     name: Github Release
     runs-on: ubuntu-latest
     needs: [deploy]
-    if: github.event_name == 'push'
+    if: ${{ github.event_name == 'push' && github.repository == '5e-bits/5e-srd-api' }}
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published}}
       version: ${{ steps.semantic.outputs.new_release_version }}
@@ -77,7 +77,7 @@ jobs:
     name: Container Release
     runs-on: ubuntu-latest
     needs: [github-release]
-    if: ${{needs.github-release.outputs.new_release_published == 'true'}}
+    if: ${{needs.github-release.outputs.new_release_published == 'true' && github.repository == '5e-bits/5e-srd-api'}}
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
## What does this do?

Deploy and child steps will not run for forked repos

## How was it tested?

Copied from 5e-bits/5e-database

## Is there a Github issue this is resolving?

No.

## Was any impacted documentation updated to reflect this change?

No.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
