### PR TITLE
feat(trait language options): Add language options to trait

### DIFF
--- a/src/graphql/resolvers/traitResolver.js
+++ b/src/graphql/resolvers/traitResolver.js
@@ -6,6 +6,7 @@ import RaceModel from '../../models/race/index.js';
 import SpellModel from '../../models/spell/index.js';
 import SubraceModel from '../../models/subrace/index.js';
 import TraitModel from '../../models/trait/index.js';
+import LanguageModel from '../../models/language/index.js';
 
 const Trait = {
   proficiencies: async trait =>
@@ -74,6 +75,19 @@ const Trait = {
     }
 
     return traitSpecificToReturn;
+  },
+  language_options: async trait => {
+    if (trait.language_options) {
+      const { language_options } = trait;
+      return resolveChoice(language_options, {
+        options: language_options.from.options.map(async option => ({
+          ...option,
+          item: await LanguageModel.findOne({ index: option.item.index }).lean(),
+        })),
+      });
+    } else {
+      return null;
+    }
   },
 };
 

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -795,6 +795,7 @@ type Trait {
   races: [Race]!
   subraces: [Subrace!]!
   proficiency_choices: ProficiencyChoice
+  language_options: LanguageChoice
   trait_specific: TraitSpecific
 }
 

--- a/src/models/trait/index.js
+++ b/src/models/trait/index.js
@@ -53,6 +53,7 @@ const Trait = new Schema({
   name: { type: String, index: true },
   proficiencies: [Proficiency],
   proficiency_choices: Choice,
+  language_options: Choice,
   races: [APIReference],
   subraces: [APIReference],
   parent: APIReference,

--- a/src/swagger/schemas/traits.yml
+++ b/src/swagger/schemas/traits.yml
@@ -66,6 +66,8 @@ trait:
             $ref: './combined.yml#/APIReference'
         proficiency_choices:
           $ref: './combined.yml#/Choice'
+        language_options:
+          $ref: './combined.yml#/Choice'
         trait_specific:
           description: 'Information specific to this trait'
           oneOf:


### PR DESCRIPTION
## What does this do?
Adds language_options to trait mongoose schema. See the [other PR](https://github.com/5e-bits/5e-database/pull/494).

## How was it tested?
Ran the API locally

## Is there a Github issue this is resolving?
n/a

## Was any impacted documentation updated to reflect this change?
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
