### PR TITLE
fix: Increase GraphQL API's max query depth

### DIFF
--- a/src/middleware/apolloServer.ts
+++ b/src/middleware/apolloServer.ts
@@ -17,7 +17,7 @@ const createApolloMiddleware = async () => {
         calculateHttpHeaders: false,
       }),
     ],
-    validationRules: [depthLimit(10)],
+    validationRules: [depthLimit(20)],
   });
   return server;
 };


### PR DESCRIPTION
## What does this do?
Increases the max depth that can be used. Some valid queries were failing because of the depth limit.

## How was it tested?
I ran the GraphQL API locally and queried it.

## Is there a Github issue this is resolving?
no

## Was any impacted documentation updated to reflect this change?
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
