### PR TITLE
feat: add size and shape to breath weapon

### DIFF
--- a/src/graphql/resolvers/common.js
+++ b/src/graphql/resolvers/common.js
@@ -216,3 +216,8 @@ export const resolveChoice = (choice, fromOverride, replace = false) => ({
     ...fromOverride,
   },
 });
+
+export const resolveAreaOfEffect = areaOfEffect => ({
+  ...areaOfEffect,
+  type: areaOfEffect.type.toUpperCase(),
+});

--- a/src/graphql/resolvers/spellResolver.js
+++ b/src/graphql/resolvers/spellResolver.js
@@ -3,14 +3,12 @@ import ClassModel from '../../models/class/index.js';
 import DamageTypeModel from '../../models/damageType/index.js';
 import MagicSchoolModel from '../../models/magicSchool/index.js';
 import SubclassModel from '../../models/subclass/index.js';
-import { levelObjectToArray } from './common.js';
+import { levelObjectToArray, resolveAreaOfEffect } from './common.js';
 
 const Spell = {
   attack_type: spell => (spell.attack_type ? spell.attack_type.toUpperCase() : null),
   area_of_effect: spell =>
-    spell.area_of_effect
-      ? { type: spell.area_of_effect.type.toUpperCase(), size: spell.area_of_effect.size }
-      : null,
+    spell.area_of_effect ? resolveAreaOfEffect(spell.area_of_effect) : null,
   casting_time: spell => {
     const { casting_time } = spell;
 

--- a/src/graphql/resolvers/traitResolver.js
+++ b/src/graphql/resolvers/traitResolver.js
@@ -1,4 +1,10 @@
-import { levelObjectToArray, resolveChoice, resolveDc, resolveUsage } from './common.js';
+import {
+  levelObjectToArray,
+  resolveAreaOfEffect,
+  resolveChoice,
+  resolveDc,
+  resolveUsage,
+} from './common.js';
 
 import DamageTypeModel from '../../models/damageType/index.js';
 import ProficiencyModel from '../../models/proficiency/index.js';
@@ -47,6 +53,7 @@ const Trait = {
           damage_type: await DamageTypeModel.findOne({ index: damage.damage_type.index }).lean(),
         })),
         usage: resolveUsage(trait_specific.breath_weapon.usage),
+        area_of_effect: resolveAreaOfEffect(trait_specific.breath_weapon.area_of_effect),
       };
     }
 

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -745,7 +745,7 @@ type BreathWeaponTrait {
   dc: BreathWeaponDc!
   usage: BreathWeaponUsage!
   damage: [BreathWeaponDamage!]!
-  size_and_shape: String
+  area_of_effect: AreaOfEffect!
 }
 
 type SpellOption {

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -745,6 +745,7 @@ type BreathWeaponTrait {
   dc: BreathWeaponDc!
   usage: BreathWeaponUsage!
   damage: [BreathWeaponDamage!]!
+  size_and_shape: String
 }
 
 type SpellOption {

--- a/src/models/common/index.js
+++ b/src/models/common/index.js
@@ -9,6 +9,12 @@ export const APIReference = new Schema({
   url: { type: String, index: true },
 });
 
+export const AreaOfEffect = new Schema({
+  _id: false,
+  size: { type: Number, required: true },
+  type: { type: String, index: true, enum: ['sphere', 'cube', 'cylinder', 'line', 'cone'] },
+});
+
 const DifficultyClass = new Schema({
   _id: false,
   dc_type: { type: APIReference, index: true },

--- a/src/models/common/types.d.ts
+++ b/src/models/common/types.d.ts
@@ -11,6 +11,12 @@ export type Choice = {
   from: OptionSet;
 };
 
+export interface AreaOfEffect {
+  _id?: mongoose.Types.ObjectId;
+  size: number;
+  type: 'sphere' | 'cube' | 'cylinder' | 'line' | 'cone';
+}
+
 type OptionSet = OptionsArrayOptionSet | EquipmentCategoryOptionSet | ResourceListOptionSet;
 
 type OptionsArrayOptionSet = {

--- a/src/models/spell/index.js
+++ b/src/models/spell/index.js
@@ -1,13 +1,7 @@
-import { APIReference } from '../common/index.js';
+import { APIReference, AreaOfEffect } from '../common/index.js';
 import mongoose from 'mongoose';
 
 const Schema = mongoose.Schema;
-
-const AreaOfEffect = new Schema({
-  _id: false,
-  size: { type: Number, required: true },
-  type: { type: String, index: true },
-});
 
 const Damage = new Schema({
   _id: false,

--- a/src/models/spell/types.d.ts
+++ b/src/models/spell/types.d.ts
@@ -1,11 +1,5 @@
 import * as mongoose from 'mongoose';
-import { APIReference } from '../common/types';
-
-interface AreaOfEffect {
-  _id?: mongoose.Types.ObjectId;
-  size: number;
-  type: string;
-}
+import { APIReference, AreaOfEffect } from '../common/types';
 
 interface Damage {
   _id?: mongoose.Types.ObjectId;

--- a/src/models/trait/index.js
+++ b/src/models/trait/index.js
@@ -36,6 +36,7 @@ const Action = new Schema({
   usage: Usage,
   dc: DC,
   damage: [ActionDamage],
+  size_and_shape: { type: String, index: true },
 });
 
 const TraitSpecific = new Schema({

--- a/src/models/trait/index.js
+++ b/src/models/trait/index.js
@@ -1,4 +1,4 @@
-import { APIReference, Choice } from '../common/index.js';
+import { APIReference, Choice, AreaOfEffect } from '../common/index.js';
 import mongoose from 'mongoose';
 
 const Schema = mongoose.Schema;
@@ -36,7 +36,7 @@ const Action = new Schema({
   usage: Usage,
   dc: DC,
   damage: [ActionDamage],
-  size_and_shape: { type: String, index: true },
+  area_of_effect: AreaOfEffect,
 });
 
 const TraitSpecific = new Schema({

--- a/src/models/trait/types.d.ts
+++ b/src/models/trait/types.d.ts
@@ -22,6 +22,7 @@ type Action = {
   usage: Usage;
   dc: DC;
   damage: ActionDamage[];
+  size_and_shape: string;
 };
 
 type TraitSpecific = {

--- a/src/models/trait/types.d.ts
+++ b/src/models/trait/types.d.ts
@@ -1,5 +1,5 @@
 import * as mongoose from 'mongoose';
-import { APIReference, Choice } from '../common/types';
+import { APIReference, Choice, AreaOfEffect } from '../common/types';
 
 type ActionDamage = {
   damage_type: APIReference;
@@ -22,7 +22,7 @@ type Action = {
   usage: Usage;
   dc: DC;
   damage: ActionDamage[];
-  size_and_shape: string;
+  area_of_effect: AreaOfEffect;
 };
 
 type TraitSpecific = {

--- a/src/swagger/schemas/combined.yml
+++ b/src/swagger/schemas/combined.yml
@@ -6,6 +6,8 @@ Damage:
   $ref: './common.yml#/damage-model'
 Choice:
   $ref: './common.yml#/choice-model'
+AreaOfEffect:
+  $ref: './common.yml#/area-of-effect-model'
 Prerequisite:
   $ref: './common.yml#/prerequisite-model'
 ResourceDescription:

--- a/src/swagger/schemas/common.yml
+++ b/src/swagger/schemas/common.yml
@@ -249,3 +249,11 @@ error-response-model:
       type: string
   required:
     - error
+area-of-effect-model:
+  type: object
+  properties:
+    size:
+      type: number
+    type:
+      type: string
+      enum: [sphere, cone, cylinder, line, cone]

--- a/src/swagger/schemas/spell.yml
+++ b/src/swagger/schemas/spell.yml
@@ -1,17 +1,17 @@
 description: |
   `Spell`
 allOf:
-  - $ref: "./combined.yml#/APIReference"
-  - $ref: "./combined.yml#/ResourceDescription"
+  - $ref: './combined.yml#/APIReference'
+  - $ref: './combined.yml#/ResourceDescription'
   - type: object
     properties:
       higher_level:
-        description: "List of descriptions for casting the spell at higher levels."
+        description: 'List of descriptions for casting the spell at higher levels.'
         type: array
         items:
           type: string
       range:
-        description: "Range of the spell, usually expressed in feet."
+        description: 'Range of the spell, usually expressed in feet.'
         type: string
       components:
         description: |
@@ -24,25 +24,27 @@ allOf:
           type: string
           enum: [V, S, M]
       material:
-        description: "Material component for the spell to be cast."
+        description: 'Material component for the spell to be cast.'
         type: string
+      area_of_effect:
+        $ref: './combined.yml#/AreaOfEffect'
       ritual:
-        description: "Determines if a spell can be cast in a 10-min(in-game) ritual."
+        description: 'Determines if a spell can be cast in a 10-min(in-game) ritual.'
         type: boolean
       duration:
-        description: "How long the spell effect lasts."
+        description: 'How long the spell effect lasts.'
         type: string
       concentration:
-        description: "Determines if a spell needs concentration to persist."
+        description: 'Determines if a spell needs concentration to persist.'
         type: boolean
       casting_time:
-        description: "How long it takes for the spell to activate."
+        description: 'How long it takes for the spell to activate.'
         type: string
       level:
-        description: "Level of the spell."
+        description: 'Level of the spell.'
         type: number
       attack_type:
-        description: "Attack type of the spell."
+        description: 'Attack type of the spell.'
         type: string
       damage:
         type: object
@@ -51,17 +53,17 @@ allOf:
             type: object
             additionalProperties: true
           damage_type:
-            $ref: "./combined.yml#/APIReference"
+            $ref: './combined.yml#/APIReference'
       school:
-        description: "Magic school this spell belongs to."
-        $ref: "./combined.yml#/APIReference"
+        description: 'Magic school this spell belongs to.'
+        $ref: './combined.yml#/APIReference'
       classes:
-        description: "List of classes that are able to learn the spell."
+        description: 'List of classes that are able to learn the spell.'
         type: array
         items:
-          $ref: "./combined.yml#/APIReference"
+          $ref: './combined.yml#/APIReference'
       subclasses:
-        description: "List of subclasses that have access to the spell."
+        description: 'List of subclasses that have access to the spell.'
         type: array
         items:
-          $ref: "./combined.yml#/APIReference"
+          $ref: './combined.yml#/APIReference'

--- a/src/swagger/schemas/traits.yml
+++ b/src/swagger/schemas/traits.yml
@@ -13,6 +13,8 @@ trait-damage:
           type: string
         desc:
           type: string
+        size_and_shape:
+          type: string
         damage:
           type: object
           properties:

--- a/src/swagger/schemas/traits.yml
+++ b/src/swagger/schemas/traits.yml
@@ -13,8 +13,8 @@ trait-damage:
           type: string
         desc:
           type: string
-        size_and_shape:
-          type: string
+        area_of_effect:
+          $ref: './combined.yml#/AreaOfEffect'
         damage:
           type: object
           properties:


### PR DESCRIPTION
## What does this do?
Adds size and shape of dragonborn's breath weapon since it wasn't in the API already

## How was it tested?
I ran the API locally and verified I could query the new property

## Is there a Github issue this is resolving?
n/a

## Was any impacted documentation updated to reflect this change?
Yes. I updated the schema in swagger

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
