### PR TITLE
fix: Malformed queries should not break the server

### DIFF
--- a/src/controllers/api/classController.js
+++ b/src/controllers/api/classController.js
@@ -14,18 +14,18 @@ export const index = async (req, res, next) => simpleController.index(req, res, 
 export const show = async (req, res, next) => simpleController.show(req, res, next);
 
 export const showLevelsForClass = async (req, res, next) => {
-  const searchQueries = {
-    'class.url': '/api/classes/' + req.params.index,
-    $or: [{ subclass: null }],
-  };
-
-  if (req.query.subclass !== undefined) {
-    searchQueries.$or.push({
-      'subclass.url': { $regex: new RegExp(escapeRegExp(req.query.subclass), 'i') },
-    });
-  }
-
   try {
+    const searchQueries = {
+      'class.url': '/api/classes/' + req.params.index,
+      $or: [{ subclass: null }],
+    };
+
+    if (req.query.subclass !== undefined) {
+      searchQueries.$or.push({
+        'subclass.url': { $regex: new RegExp(escapeRegExp(req.query.subclass), 'i') },
+      });
+    }
+
     const data = await Level.find(searchQueries).sort({ level: 'asc' });
     if (data && data.length) {
       return res.status(200).json(data);
@@ -38,13 +38,13 @@ export const showLevelsForClass = async (req, res, next) => {
 };
 
 export const showLevelForClass = async (req, res, next) => {
-  if (!Number.isInteger(parseInt(req.params.level))) {
-    return res.status(404).json({ error: 'Not found' });
-  }
-
-  const urlString = '/api/classes/' + req.params.index + '/levels/' + req.params.level;
-
   try {
+    if (!Number.isInteger(parseInt(req.params.level))) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    const urlString = '/api/classes/' + req.params.index + '/levels/' + req.params.level;
+
     const data = await Level.findOne({ url: urlString });
     if (!data) return next();
     return res.status(200).json(data);
@@ -54,9 +54,9 @@ export const showLevelForClass = async (req, res, next) => {
 };
 
 export const showMulticlassingForClass = async (req, res, next) => {
-  const urlString = '/api/classes/' + req.params.index;
-
   try {
+    const urlString = '/api/classes/' + req.params.index;
+
     const data = await Class.findOne({ url: urlString });
     return res.status(200).json(data.multi_classing);
   } catch (err) {
@@ -65,9 +65,9 @@ export const showMulticlassingForClass = async (req, res, next) => {
 };
 
 export const showSubclassesForClass = async (req, res, next) => {
-  const urlString = '/api/classes/' + req.params.index;
-
   try {
+    const urlString = '/api/classes/' + req.params.index;
+
     const data = await Subclass.find({ 'class.url': urlString })
       .select({ index: 1, name: 1, url: 1, _id: 0 })
       .sort({ url: 'asc', level: 'asc' });
@@ -107,9 +107,9 @@ export const showSpellcastingForClass = async (req, res, next) => {
 };
 
 export const showSpellsForClass = async (req, res, next) => {
-  const urlString = '/api/classes/' + req.params.index;
-
   try {
+    const urlString = '/api/classes/' + req.params.index;
+
     const data = await Spell.find({ 'classes.url': urlString })
       .select({ index: 1, name: 1, url: 1, _id: 0 })
       .sort({ level: 'asc', url: 'asc' });
@@ -120,13 +120,13 @@ export const showSpellsForClass = async (req, res, next) => {
 };
 
 export const showSpellsForClassAndLevel = async (req, res, next) => {
-  if (!Number.isInteger(parseInt(req.params.level))) {
-    return res.status(404).json({ error: 'Not found' });
-  }
-
-  const urlString = '/api/classes/' + req.params.index;
-
   try {
+    if (!Number.isInteger(parseInt(req.params.level))) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    const urlString = '/api/classes/' + req.params.index;
+
     const data = await Spell.find({
       'classes.url': urlString,
       level: parseInt(req.params.level),
@@ -140,9 +140,9 @@ export const showSpellsForClassAndLevel = async (req, res, next) => {
 };
 
 export const showFeaturesForClass = async (req, res, next) => {
-  const urlString = '/api/classes/' + req.params.index;
-
   try {
+    const urlString = '/api/classes/' + req.params.index;
+
     const data = await Feature.find({
       'class.url': urlString,
     })
@@ -155,13 +155,13 @@ export const showFeaturesForClass = async (req, res, next) => {
 };
 
 export const showFeaturesForClassAndLevel = async (req, res, next) => {
-  if (!Number.isInteger(parseInt(req.params.level))) {
-    return res.status(404).json({ error: 'Not found' });
-  }
-
-  const urlString = '/api/classes/' + req.params.index;
-
   try {
+    if (!Number.isInteger(parseInt(req.params.level))) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    const urlString = '/api/classes/' + req.params.index;
+
     const data = await Feature.find({
       'class.url': urlString,
       level: parseInt(req.params.level),
@@ -175,9 +175,9 @@ export const showFeaturesForClassAndLevel = async (req, res, next) => {
 };
 
 export const showProficienciesForClass = async (req, res, next) => {
-  const urlString = '/api/classes/' + req.params.index;
-
   try {
+    const urlString = '/api/classes/' + req.params.index;
+
     const data = await Proficiency.find({ 'classes.url': urlString })
       .select({ index: 1, name: 1, url: 1, _id: 0 })
       .sort({ index: 'asc' });

--- a/src/controllers/api/magicItemController.js
+++ b/src/controllers/api/magicItemController.js
@@ -3,32 +3,28 @@ import { ResourceList, escapeRegExp, redisClient } from '../../util/index.js';
 import MagicItem from '../../models/magicItem/index.js';
 
 export const index = async (req, res, next) => {
-  const searchQueries = {};
-  if (req.query.name !== undefined) {
-    searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
-  }
-
-  const redisKey = req.originalUrl;
-  let data;
   try {
-    data = await redisClient.get(redisKey);
-  } catch (err) {
-    return;
-  }
+    const searchQueries = {};
+    if (req.query.name !== undefined) {
+      searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
+    }
 
-  if (data) {
-    res.status(200).json(JSON.parse(data));
-  } else {
-    try {
+    const redisKey = req.originalUrl;
+    let data;
+    data = await redisClient.get(redisKey);
+
+    if (data) {
+      res.status(200).json(JSON.parse(data));
+    } else {
       const data = await MagicItem.find(searchQueries)
         .select({ index: 1, name: 1, url: 1, _id: 0 })
         .sort({ index: 'asc' });
       const jsonData = ResourceList(data);
       redisClient.set(redisKey, JSON.stringify(jsonData));
       return res.status(200).json(jsonData);
-    } catch (err) {
-      next(err);
     }
+  } catch (err) {
+    next(err);
   }
 };
 

--- a/src/controllers/api/raceController.js
+++ b/src/controllers/api/raceController.js
@@ -11,9 +11,9 @@ export const index = async (req, res, next) => simpleController.index(req, res, 
 export const show = async (req, res, next) => simpleController.show(req, res, next);
 
 export const showSubracesForRace = async (req, res, next) => {
-  const urlString = '/api/races/' + req.params.index;
-
   try {
+    const urlString = '/api/races/' + req.params.index;
+
     const data = await Subrace.find({ 'race.url': urlString }).select({
       index: 1,
       name: 1,
@@ -27,9 +27,9 @@ export const showSubracesForRace = async (req, res, next) => {
 };
 
 export const showTraitsForRace = async (req, res, next) => {
-  const urlString = '/api/races/' + req.params.index;
-
   try {
+    const urlString = '/api/races/' + req.params.index;
+
     const data = await Trait.find({ 'races.url': urlString }).select({
       index: 1,
       name: 1,
@@ -43,9 +43,9 @@ export const showTraitsForRace = async (req, res, next) => {
 };
 
 export const showProficienciesForRace = async (req, res, next) => {
-  const urlString = '/api/races/' + req.params.index;
-
   try {
+    const urlString = '/api/races/' + req.params.index;
+
     const data = await Proficiency.find({ 'races.url': urlString })
       .select({ index: 1, name: 1, url: 1, _id: 0 })
       .sort({ index: 'asc' });

--- a/src/controllers/api/ruleController.js
+++ b/src/controllers/api/ruleController.js
@@ -3,35 +3,30 @@ import { ResourceList, escapeRegExp, redisClient } from '../../util/index.js';
 import Rule from '../../models/rule/index.js';
 
 export const index = async (req, res, next) => {
-  const searchQueries = {};
-  if (req.query.name !== undefined) {
-    searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
-  }
-  if (req.query.desc !== undefined) {
-    searchQueries.desc = { $regex: new RegExp(escapeRegExp(req.query.desc), 'i') };
-  }
-
-  const redisKey = req.originalUrl;
-  let data;
   try {
-    data = await redisClient.get(redisKey);
-  } catch (err) {
-    return;
-  }
+    const searchQueries = {};
+    if (req.query.name !== undefined) {
+      searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
+    }
+    if (req.query.desc !== undefined) {
+      searchQueries.desc = { $regex: new RegExp(escapeRegExp(req.query.desc), 'i') };
+    }
 
-  if (data) {
-    res.status(200).json(JSON.parse(data));
-  } else {
-    try {
+    const redisKey = req.originalUrl;
+    let data;
+    data = await redisClient.get(redisKey);
+    if (data) {
+      res.status(200).json(JSON.parse(data));
+    } else {
       const data = await Rule.find(searchQueries)
         .select({ index: 1, name: 1, url: 1, _id: 0 })
         .sort({ index: 'asc' });
       const jsonData = ResourceList(data);
       redisClient.set(redisKey, JSON.stringify(jsonData));
       return res.status(200).json(jsonData);
-    } catch (err) {
-      next(err);
     }
+  } catch (err) {
+    next(err);
   }
 };
 

--- a/src/controllers/api/ruleSectionController.js
+++ b/src/controllers/api/ruleSectionController.js
@@ -3,35 +3,31 @@ import { ResourceList, escapeRegExp, redisClient } from '../../util/index.js';
 import RuleSection from '../../models/ruleSection/index.js';
 
 export const index = async (req, res, next) => {
-  const searchQueries = {};
-  if (req.query.name !== undefined) {
-    searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
-  }
-  if (req.query.desc !== undefined) {
-    searchQueries.desc = { $regex: new RegExp(escapeRegExp(req.query.desc), 'i') };
-  }
-
-  const redisKey = req.originalUrl;
-  let data;
   try {
-    data = await redisClient.get(redisKey);
-  } catch (err) {
-    return;
-  }
+    const searchQueries = {};
+    if (req.query.name !== undefined) {
+      searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
+    }
+    if (req.query.desc !== undefined) {
+      searchQueries.desc = { $regex: new RegExp(escapeRegExp(req.query.desc), 'i') };
+    }
 
-  if (data) {
-    res.status(200).json(JSON.parse(data));
-  } else {
-    try {
+    const redisKey = req.originalUrl;
+    let data;
+    data = await redisClient.get(redisKey);
+
+    if (data) {
+      res.status(200).json(JSON.parse(data));
+    } else {
       const data = await RuleSection.find(searchQueries)
         .select({ index: 1, name: 1, url: 1, _id: 0 })
         .sort({ index: 'asc' });
       const jsonData = ResourceList(data);
       redisClient.set(redisKey, JSON.stringify(jsonData));
       return res.status(200).json(jsonData);
-    } catch (err) {
-      next(err);
     }
+  } catch (err) {
+    next(err);
   }
 };
 

--- a/src/controllers/api/spellController.js
+++ b/src/controllers/api/spellController.js
@@ -3,46 +3,42 @@ import { ResourceList, escapeRegExp, redisClient } from '../../util/index.js';
 import Spell from '../../models/spell/index.js';
 
 export const index = async (req, res, next) => {
-  const searchQueries = {};
-  if (req.query.name !== undefined) {
-    searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
-  }
-
-  if (req.query.level !== undefined) {
-    searchQueries.level = { $in: req.query.level };
-  }
-
-  if (req.query.school !== undefined) {
-    let schoolRegex;
-    if (Array.isArray(req.query.school)) {
-      schoolRegex = req.query.school.map(c => new RegExp(escapeRegExp(c), 'i'));
-    } else {
-      schoolRegex = [new RegExp(escapeRegExp(req.query.school), 'i')];
-    }
-    searchQueries['school.name'] = { $in: schoolRegex };
-  }
-
-  const redisKey = req.originalUrl;
-  let data;
   try {
-    data = await redisClient.get(redisKey);
-  } catch (err) {
-    return;
-  }
+    const searchQueries = {};
+    if (req.query.name !== undefined) {
+      searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
+    }
 
-  if (data) {
-    res.status(200).json(JSON.parse(data));
-  } else {
-    try {
+    if (req.query.level !== undefined) {
+      searchQueries.level = { $in: req.query.level };
+    }
+
+    if (req.query.school !== undefined) {
+      let schoolRegex;
+      if (Array.isArray(req.query.school)) {
+        schoolRegex = req.query.school.map(c => new RegExp(escapeRegExp(c), 'i'));
+      } else {
+        schoolRegex = [new RegExp(escapeRegExp(req.query.school), 'i')];
+      }
+      searchQueries['school.name'] = { $in: schoolRegex };
+    }
+
+    const redisKey = req.originalUrl;
+    let data;
+    data = await redisClient.get(redisKey);
+
+    if (data) {
+      res.status(200).json(JSON.parse(data));
+    } else {
       const data = await Spell.find(searchQueries)
         .select({ index: 1, name: 1, url: 1, _id: 0 })
         .sort({ index: 'asc' });
       const jsonData = ResourceList(data);
       redisClient.set(redisKey, JSON.stringify(jsonData));
       return res.status(200).json(jsonData);
-    } catch (err) {
-      next(err);
     }
+  } catch (err) {
+    next(err);
   }
 };
 

--- a/src/controllers/api/subclassController.js
+++ b/src/controllers/api/subclassController.js
@@ -10,9 +10,9 @@ export const index = async (req, res, next) => simpleController.index(req, res, 
 export const show = async (req, res, next) => simpleController.show(req, res, next);
 
 export const showLevelsForSubclass = async (req, res, next) => {
-  const urlString = '/api/subclasses/' + req.params.index;
-
   try {
+    const urlString = '/api/subclasses/' + req.params.index;
+
     const data = await Level.find({ 'subclass.url': urlString }).sort({ level: 'asc' });
     return res.status(200).json(data);
   } catch (err) {
@@ -21,13 +21,13 @@ export const showLevelsForSubclass = async (req, res, next) => {
 };
 
 export const showLevelForSubclass = async (req, res, next) => {
-  if (!Number.isInteger(parseInt(req.params.level))) {
-    return res.status(404).json({ error: 'Not found' });
-  }
-
-  const urlString = '/api/subclasses/' + req.params.index + '/levels/' + req.params.level;
-
   try {
+    if (!Number.isInteger(parseInt(req.params.level))) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    const urlString = '/api/subclasses/' + req.params.index + '/levels/' + req.params.level;
+
     const data = await Level.findOne({ url: urlString });
     if (!data) return next();
     return res.status(200).json(data);
@@ -37,9 +37,9 @@ export const showLevelForSubclass = async (req, res, next) => {
 };
 
 export const showFeaturesForSubclass = async (req, res, next) => {
-  const urlString = '/api/subclasses/' + req.params.index;
-
   try {
+    const urlString = '/api/subclasses/' + req.params.index;
+
     const data = await Feature.find({
       'subclass.url': urlString,
     })
@@ -52,13 +52,13 @@ export const showFeaturesForSubclass = async (req, res, next) => {
 };
 
 export const showFeaturesForSubclassAndLevel = async (req, res, next) => {
-  if (!Number.isInteger(parseInt(req.params.level))) {
-    return res.status(404).json({ error: 'Not found' });
-  }
-
-  const urlString = '/api/subclasses/' + req.params.index;
-
   try {
+    if (!Number.isInteger(parseInt(req.params.level))) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    const urlString = '/api/subclasses/' + req.params.index;
+
     const data = await Feature.find({
       level: parseInt(req.params.level),
       'subclass.url': urlString,

--- a/src/controllers/api/subraceController.js
+++ b/src/controllers/api/subraceController.js
@@ -10,8 +10,8 @@ export const index = async (req, res, next) => simpleController.index(req, res, 
 export const show = async (req, res, next) => simpleController.show(req, res, next);
 
 export const showTraitsForSubrace = async (req, res, next) => {
-  const urlString = '/api/subraces/' + req.params.index;
   try {
+    const urlString = '/api/subraces/' + req.params.index;
     const data = await Trait.find({ 'subraces.url': urlString }).select({
       index: 1,
       name: 1,
@@ -26,9 +26,9 @@ export const showTraitsForSubrace = async (req, res, next) => {
 };
 
 export const showProficienciesForSubrace = async (req, res, next) => {
-  const urlString = '/api/subraces/' + req.params.index;
-
   try {
+    const urlString = '/api/subraces/' + req.params.index;
+
     const data = await Proficiency.find({ 'races.url': urlString })
       .select({ index: 1, name: 1, url: 1, _id: 0 })
       .sort({ index: 'asc' });

--- a/src/controllers/simpleController.js
+++ b/src/controllers/simpleController.js
@@ -7,12 +7,12 @@ class SimpleController {
   }
 
   async index(req, res, next) {
-    const searchQueries = {};
-    if (req.query.name !== undefined) {
-      searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
-    }
-
     try {
+      const searchQueries = {};
+      if (req.query.name !== undefined) {
+        searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
+      }
+
       const data = await this.Schema.find(searchQueries)
         .select({ index: 1, name: 1, url: 1, _id: 0 })
         .sort({ index: 'asc' })


### PR DESCRIPTION
## What does this do?

The server gets brought down sometimes due to bad queries. We should wrap everything in the try/catch block so it doesn't crash.

## How was it tested?


CI

## Is there a Github issue this is resolving?

No. Just realized it from the outage today.

## Was any impacted documentation updated to reflect this change?

No.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
