### PR TITLE
fix: Fix issue with fetching cleric starting equipment options with prerequisites

### DIFF
--- a/src/graphql/resolvers/classResolver.js
+++ b/src/graphql/resolvers/classResolver.js
@@ -11,6 +11,10 @@ const resolveEquipmentOption = async option => {
     return {
       ...option,
       of: await EquipmentModel.findOne({ index: option.of.index }).lean(),
+      prerequisites: option.prerequisites?.map(async prereq => ({
+        ...prereq,
+        proficiency: await ProficiencyModel.findOne({ index: prereq.proficiency.index }).lean(),
+      })),
     };
   }
 


### PR DESCRIPTION
## What does this do?
As the title says. If you run the following query: 
```graphql
query Class {
		class(index: "cleric") {
			starting_equipment_options {
				choose
				desc
				from {
					... on EquipmentCategoryOptionSet {
						equipment_category {
							index
							name
						}
					}
					... on EquipmentOptionSet {
						options {
							... on CountedReferenceOption {
								count
								of {
									index
									name
									... on Pack {
										contents {
											quantity
											item {
												index
												name
											}
										}
									}
								}
								prerequisites {
									type
									proficiency {
										name
										type
										index
									}
								}
							}
							... on EquipmentCategoryChoiceOption {
								choice {
									choose
									from {
										equipment_category {
											index
											name
										}
									}
								}
							}
							... on EquipmentMultipleOption {
								items {
									... on CountedReferenceOption {
										count
										of {
											index
											name
											... on Pack {
												contents {
													quantity
													item {
														index
														name
													}
												}
											}
										}
										prerequisites {
											type
											proficiency {
												index
												name
												type
											}
										}
									}
									... on EquipmentCategoryChoiceOption {
										choice {
											choose
											from {
												equipment_category {
													index
													name
												}
											}
										}
									}
								}
							}
						}
					}
				}
			}
		}
	}
```
You get this error:
<img width="657" alt="prerequisites error" src="https://user-images.githubusercontent.com/28871516/185545021-b3e679bb-1e1d-4c91-9238-2e4db9906b2f.png">

## How was it tested?
I ran the API locally and queried it.

## Is there a Github issue this is resolving?
n/a

## Was any impacted documentation updated to reflect this change?
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
