### PR TITLE
fix: add common rarity to magic items rarity enum

### DIFF
--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -79,6 +79,7 @@ interface IEquipmentBase {
 
 enum MagicItemRarity {
   VARIES
+  COMMON
   UNCOMMON
   RARE
   VERY_RARE


### PR DESCRIPTION
## What does this do?
This PR fixes the issue that when quering the API using GraphQL for Magic Items and there is a magic Item with Common Rarity, the API return a 500 response because there no "Common" rarity listed on the enum for the GrapQL.

## How was it tested?
Using the Apollo sandbox explorer perform the following query with the following Variables:
Query:
```graphql
query MagicItemsQuery($equipmentCategory: StringFilter, $order: MagicItemOrder) {
  magicItems(equipment_category: $equipmentCategory, order: $order) {
    index
    name
    desc
    rarity
    equipment_category {
      index
      name
    }
  }
}
```

Variables
```json
{
  "equipmentCategory": null,
  "order": {
    "by": "EQUIPMENT_CATEGORY",
    "direction": "ASCENDING",
    "then_by": {
      "by": "NAME",
      "direction": "ASCENDING",
    }
  }
}
```

## Is there a Github issue this is resolving?
This resolves issue #331

## Was any impacted documentation updated to reflect this change?
\<It's not clear if I don't update this text with relevant info\>

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
