### PR TITLE
fix: (src/5e-SRD-Monsters.json): added modifiers to hit dice

### DIFF
--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -669,6 +669,7 @@ type Monster {
   forms: [Monster!]
   hit_dice: String!
   hit_points: Int!
+  hit_points_roll: String!
   intelligence: Int!
   languages: String!
   legendary_actions: [LegendaryAction!]

--- a/src/models/monster/index.js
+++ b/src/models/monster/index.js
@@ -140,6 +140,7 @@ const Monster = new Schema({
   forms: { type: [APIReference], default: undefined },
   hit_dice: { type: String, index: true },
   hit_points: { type: Number, index: true },
+  hit_points_roll: { type: String, index: true },
   index: { type: String, index: true },
   intelligence: { type: Number, index: true },
   languages: { type: String, index: true },

--- a/src/models/monster/types.d.ts
+++ b/src/models/monster/types.d.ts
@@ -130,6 +130,7 @@ export type Monster = {
   forms?: APIReference[];
   hit_dice: string;
   hit_points: number;
+  hit_points_roll: string;
   index: string;
   intelligence: number;
   languages: string[];

--- a/src/swagger/paths/monsters.yml
+++ b/src/swagger/paths/monsters.yml
@@ -110,6 +110,7 @@ monster-index:
               forms: []
               hit_dice: 18d10
               hit_points: 135
+              hit_points_roll: 18d10+36
               intelligence: 18
               languages: Deep Speech, telepathy 120 ft.
               legendary_actions:

--- a/src/swagger/schemas/monsters.yml
+++ b/src/swagger/schemas/monsters.yml
@@ -247,6 +247,9 @@ monster-model:
         hit_dice:
           description: 'The hit die of a monster can be used to make a version of the same monster whose hit points are determined by the roll of the die. For example: A monster with 2d6 would have its hit points determine by rolling a 6 sided die twice.'
           type: string
+        hit_points_roll:
+          description: "The roll for determining a monster's hit points, which consists of the hit dice (e.g. 18d10) and the modifier determined by its Constitution (e.g. +36). For example, 18d10+36"
+          type: string
         actions:
           description: 'A list of actions that are available to the monster to take during combat.'
           type: array


### PR DESCRIPTION
## What does this do?
I saw @Stuart-Yee [added a new field to monsters for hit points rolls.](https://github.com/5e-bits/5e-database/pull/500) I updated the GraphQL schema to have the new property.

## How was it tested?
I honestly can't test this unless I was able to use the database changes in Stuart's branch, but the change is simply adding a primitive type property to a type, so there's not any logic to test.

## Is there a Github issue this is resolving?
No.

## Was any impacted documentation updated to reflect this change?
Yes

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
