### PR TITLE
fix: add ARTIFACT rarity to magic items rarity enum

### DIFF
--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -84,6 +84,7 @@ enum MagicItemRarity {
   RARE
   VERY_RARE
   LEGENDARY
+  ARTIFACT
 }
 
 type MagicItem implements IEquipmentBase {


### PR DESCRIPTION
## What does this do?
This PR fixes the issue that when quering the API using GraphQL for Magic Items and there is a magic Item with Common Rarity, the API return a 500 response because there no "ARTIFACT" rarity listed on the enum for the GraphQL.

## How was it tested?
Using the Apollo sandbox explorer perform the following query with the following Variables:
Query:

```graphql
query MagicItemsQuery($equipmentCategory: StringFilter, $order: MagicItemOrder) {
  magicItems(equipment_category: $equipmentCategory, order: $order) {
    index
    name
    desc
    rarity
    equipment_category {
      index
      name
    }
  }
}
```

## Is there a Github issue this is resolving?
#331 (ish)

## Was any impacted documentation updated to reflect this change?
N/A

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
