### PR TITLE
fix: Add image to GraphQL resolver

### DIFF
--- a/src/graphql/resolvers/queryResolver.js
+++ b/src/graphql/resolvers/queryResolver.js
@@ -444,6 +444,10 @@ const Query = {
       filters.push(resolveContainsStringFilter(args.name));
     }
 
+    if (args.image) {
+      filters.push(resolveContainsStringFilter(args.image, 'image'));
+    }
+
     if (args.size) {
       filters.push({ size: { $in: args.size } });
     }


### PR DESCRIPTION
## What does this do?
I missed adding this resolver when I added images.

## How was it tested?
N/A

## Is there a Github issue this is resolving?
Not yet

## Was any impacted documentation updated to reflect this change?
I don't think so?

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
