### PR TITLE
fix: Add monster image to GraphQL API

### DIFF
--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -686,6 +686,7 @@ type Monster {
   type: MonsterType!
   wisdom: Int!
   xp: Int!
+  image: String
 }
 
 type ProficiencyReferenceOption {

--- a/src/models/monster/types.d.ts
+++ b/src/models/monster/types.d.ts
@@ -131,7 +131,7 @@ export type Monster = {
   hit_dice: string;
   hit_points: number;
   hit_points_roll: string;
-  image: string;
+  image?: string;
   index: string;
   intelligence: number;
   languages: string[];


### PR DESCRIPTION
## What does this do?
Adds monster image url to GraphQL API

## How was it tested?
n/a

## Is there a Github issue this is resolving?
n/a

## Was any impacted documentation updated to reflect this change?
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
