### PR TITLE
fix: CR query shouldn't break with lists

### DIFF
--- a/src/controllers/api/monsterController.js
+++ b/src/controllers/api/monsterController.js
@@ -9,6 +9,12 @@ export const index = async (req, res, next) => {
       searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
     }
     if (req.query.challenge_rating !== undefined) {
+      if (isNaN(Number(req.query.challenge_rating))) {
+        req.query.challenge_rating = req.query.challenge_rating
+          .split(',')
+          .map(Number)
+          .filter(item => !isNaN(item));
+      }
       searchQueries.challenge_rating = { $in: req.query.challenge_rating };
     }
 

--- a/src/controllers/api/monsterController.js
+++ b/src/controllers/api/monsterController.js
@@ -9,7 +9,7 @@ export const index = async (req, res, next) => {
       searchQueries.name = { $regex: new RegExp(escapeRegExp(req.query.name), 'i') };
     }
     if (req.query.challenge_rating !== undefined) {
-      if (isNaN(Number(req.query.challenge_rating))) {
+      if (typeof req.query.challenge_rating === 'string') {
         req.query.challenge_rating = req.query.challenge_rating
           .split(',')
           .map(Number)

--- a/src/tests/integration/api/monsters.itest.ts
+++ b/src/tests/integration/api/monsters.itest.ts
@@ -91,6 +91,10 @@ describe('/api/monsters', () => {
         expect(bothRes.statusCode).toEqual(200);
         expect(bothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
 
+        const altBothRes = await request(app).get(`/api/monsters?challenge_rating=${cr1},${cr20}`);
+        expect(altBothRes.statusCode).toEqual(200);
+        expect(altBothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
+
         const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
         const randomResult = bothRes.body.results[randomIndex];
 


### PR DESCRIPTION
## What does this do?
Allows the API to handle CR queries like `challenge_rating=1,2`. It won't allow `challenge_rating=[1,2]` to crash the API as a malformed query.

## How was it tested?
Locally

## Is there a Github issue this is resolving?
Nope

## Was any impacted documentation updated to reflect this change?
No

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/205165109-b9bc172b-bc76-441b-bbb4-f9bb1d47430c.png)
