### PR TITLE
feat: Add Monster Armor Types

### DIFF
--- a/src/graphql/resolvers/monsterResolver.ts
+++ b/src/graphql/resolvers/monsterResolver.ts
@@ -50,7 +50,7 @@ const Monster = {
     const resolvedAC = monster.armor_class.map(async ac => {
       const newAC: Record<string, any> = { ...ac };
 
-      if (ac.type === 'armor') {
+      if (ac.type === 'armor' && 'armor' in ac) {
         newAC.armor = await EquipmentModel.find({
           index: { $in: ac.armor?.map(({ index }) => index) ?? [] },
         });

--- a/src/graphql/resolvers/monsterResolver.ts
+++ b/src/graphql/resolvers/monsterResolver.ts
@@ -51,8 +51,8 @@ const Monster = {
       const newAC: Record<string, any> = { ...ac };
 
       if (ac.type === 'armor') {
-        newAC.armor = ac.armor?.map(async armor => {
-          return await EquipmentModel.findOne({ index: armor.index }).lean();
+        newAC.armor = await EquipmentModel.find({
+          index: { $in: ac.armor?.map(({ index }) => index) ?? [] },
         });
       }
 

--- a/src/graphql/resolvers/queryResolver.ts
+++ b/src/graphql/resolvers/queryResolver.ts
@@ -470,10 +470,6 @@ const Query = {
       filters.push({ damage_vulnerabilities: { $elemMatch: { $in: args.damage_vulnerability } } });
     }
 
-    if (args.armor_class) {
-      filters.push(resolveNumberFilter(args.armor_class, 'armor_class'));
-    }
-
     if (args.challenge_rating) {
       filters.push(resolveNumberFilter(args.challenge_rating, 'challenge_rating'));
     }

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -658,7 +658,7 @@ type MonsterArmorClass {
   type: String!
   desc: String
   value: Int!
-  armor: [Equipment]
+  armor: [IEquipment]
   spell: Spell
   condition: Condition
 }

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -654,11 +654,19 @@ type MonsterAction {
   usage: Usage
 }
 
+enum MonsterArmorClassType {
+  dex
+  natural
+  armor
+  spell
+  condition
+}
+
 type MonsterArmorClass {
-  type: String!
+  type: MonsterArmorClassType!
   desc: String
   value: Int!
-  armor: [IEquipment]
+  armor: [Armor]
   spell: Spell
   condition: Condition
 }
@@ -666,7 +674,7 @@ type MonsterArmorClass {
 type Monster {
   index: String!
   name: String!
-  armor_class: MonsterArmorClass!
+  armor_class: [MonsterArmorClass]
   desc: String
   actions: [MonsterAction!]
   challenge_rating: Float!

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -654,10 +654,19 @@ type MonsterAction {
   usage: Usage
 }
 
+type MonsterArmorClass {
+  type: String!
+  desc: String
+  value: Int!
+  armor: [Equipment]
+  spell: Spell
+  condition: Condition
+}
+
 type Monster {
   index: String!
   name: String!
-  armor_class: Int!
+  armor_class: MonsterArmorClass!
   desc: String
   actions: [MonsterAction!]
   challenge_rating: Float!

--- a/src/models/common/index.ts
+++ b/src/models/common/index.ts
@@ -76,12 +76,10 @@ const Option = new Schema<Option>(
 Option.discriminators = {};
 
 Option.discriminators['reference'] = new Schema<ReferenceOption>({
-  _id: false,
   item: { type: APIReferenceSchema, index: true, required: true },
 });
 
 Option.discriminators['action'] = new Schema<ActionOption>({
-  _id: false,
   action_name: { type: String, index: true, required: true },
   count: { type: Schema.Types.Mixed, index: true, required: true },
   type: {
@@ -94,48 +92,40 @@ Option.discriminators['action'] = new Schema<ActionOption>({
 });
 
 Option.discriminators['multiple'] = new Schema<MultipleOption>({
-  _id: false,
   items: { type: [Option], index: true, required: true },
 });
 
 Option.discriminators['string'] = new Schema<StringOption>({
-  _id: false,
   string: { type: String, index: true, required: true },
 });
 
 Option.discriminators['ideal'] = new Schema<IdealOption>({
-  _id: false,
   desc: { type: String, index: true, required: true },
   alignments: { type: [APIReferenceSchema], index: true, required: true },
 });
 
 Option.discriminators['counted_reference'] = new Schema<CountedReferenceOption>({
-  _id: false,
   count: { type: Number, index: true, required: true },
   of: { type: APIReferenceSchema, index: true, required: true },
 });
 
 Option.discriminators['score_prerequisite'] = new Schema<ScorePrerequisiteOption>({
-  _id: false,
   ability_score: { type: APIReferenceSchema, index: true, required: true },
   minimum_score: { type: Number, index: true, required: true },
 });
 
 Option.discriminators['ability_bonus'] = new Schema<AbilityBonusOption>({
-  _id: false,
   ability_score: { type: APIReferenceSchema, index: true, required: true },
   bonus: { type: Number, index: true, required: true },
 });
 
 Option.discriminators['breath'] = new Schema<BreathOption>({
-  _id: false,
   name: { type: String, index: true, required: true },
   dc: { type: DifficultyClassSchema, index: true, required: true },
   damage: { type: [DamageSchema], index: true },
 });
 
 Option.discriminators['damage'] = new Schema<DamageOption>({
-  _id: false,
   damage_type: { type: APIReferenceSchema, index: true, required: true },
   damage_dice: { type: String, index: true, required: true },
   notes: { type: String, index: true },
@@ -157,17 +147,14 @@ const OptionSetSchema = new Schema<OptionSet>(
 OptionSetSchema.discriminators = {};
 
 OptionSetSchema.discriminators['equipment_category'] = new Schema<EquipmentCategoryOptionSet>({
-  _id: false,
   equipment_category: { type: APIReferenceSchema, index: true, required: true },
 });
 
 OptionSetSchema.discriminators['resource_list'] = new Schema<ResourceListOptionSet>({
-  _id: false,
   resource_list_url: { type: String, index: true, required: true },
 });
 
 OptionSetSchema.discriminators['options_array'] = new Schema<OptionsArrayOptionSet>({
-  _id: false,
   options: { type: [Option], index: true, required: true },
 });
 
@@ -180,6 +167,5 @@ export const ChoiceSchema = new Schema<Choice>({
 });
 
 Option.discriminators['choice'] = new Schema<ChoiceOption>({
-  _id: false,
   choice: { type: ChoiceSchema, index: true, required: true },
 });

--- a/src/models/feature/index.ts
+++ b/src/models/feature/index.ts
@@ -19,15 +19,12 @@ const PrerequisiteSchema = new Schema<Prerequisite>(
 
 PrerequisiteSchema.discriminators = {};
 PrerequisiteSchema.discriminators['level'] = new Schema<LevelPrerequisite>({
-  _id: false,
   level: { type: Number, index: true, required: true },
 });
 PrerequisiteSchema.discriminators['feature'] = new Schema<FeaturePrerequisite>({
-  _id: false,
   feature: { type: String, index: true, required: true },
 });
 PrerequisiteSchema.discriminators['spell'] = new Schema<SpellPrerequisite>({
-  _id: false,
   spell: { type: String, index: true, required: true },
 });
 

--- a/src/models/monster/index.ts
+++ b/src/models/monster/index.ts
@@ -9,6 +9,12 @@ import {
   Action,
   ActionOption,
   ActionUsage,
+  ArmorClass,
+  ArmorClassArmor,
+  ArmorClassCondition,
+  ArmorClassDex,
+  ArmorClassNatural,
+  ArmorClassSpell,
   LegendaryAction,
   Proficiency,
   Reaction,
@@ -46,6 +52,46 @@ const ActionSchema = new Schema<Action>({
   multiattack_type: { type: String, index: true, enum: ['actions', 'action_options'] },
   action_options: { type: ChoiceSchema, index: true },
   actions: { type: [ActionOptionSchema], index: true },
+});
+
+const ArmorClassSchema = new Schema<ArmorClass>(
+  {
+    _id: false,
+    type: { type: String, index: true, enum: ['dex', 'natural', 'armor', 'spell', 'condition'] },
+  },
+  { discriminatorKey: 'type', _id: false }
+);
+
+ArmorClassSchema.discriminators = {};
+ArmorClassSchema.discriminators.dex = new Schema<ArmorClassDex>({
+  _id: false,
+  value: { type: Number, index: true },
+});
+
+ArmorClassSchema.discriminators.natural = new Schema<ArmorClassNatural>({
+  _id: false,
+  value: { type: Number, index: true },
+});
+
+ArmorClassSchema.discriminators.armor = new Schema<ArmorClassArmor>({
+  _id: false,
+  value: { type: Number, index: true },
+  armor: { type: [APIReferenceSchema], index: true },
+  desc: { type: String, index: true },
+});
+
+ArmorClassSchema.discriminators.spell = new Schema<ArmorClassSpell>({
+  _id: false,
+  value: { type: Number, index: true },
+  spell: { type: APIReferenceSchema, index: true },
+  desc: { type: String, index: true },
+});
+
+ArmorClassSchema.discriminators.condition = new Schema<ArmorClassCondition>({
+  _id: false,
+  value: { type: Number, index: true },
+  condition: { type: APIReferenceSchema, index: true },
+  desc: { type: String, index: true },
 });
 
 const LegendaryActionSchema = new Schema<LegendaryAction>({
@@ -133,7 +179,7 @@ const Monster = new Schema<Monster>({
   _id: { type: String, select: false },
   actions: [ActionSchema],
   alignment: { type: String, index: true },
-  armor_class: { type: Number, index: true },
+  armor_class: [ArmorClassSchema],
   challenge_rating: { type: Number, index: true },
   charisma: { type: Number, index: true },
   condition_immunities: [APIReferenceSchema],

--- a/src/models/monster/index.ts
+++ b/src/models/monster/index.ts
@@ -70,21 +70,15 @@ ArmorClassSchema.discriminators.dex = new Schema<ArmorClassDex>({});
 ArmorClassSchema.discriminators.natural = new Schema<ArmorClassNatural>({});
 
 ArmorClassSchema.discriminators.armor = new Schema<ArmorClassArmor>({
-  value: { type: Number, index: true },
   armor: { type: [APIReferenceSchema], index: true },
-  desc: { type: String, index: true },
 });
 
 ArmorClassSchema.discriminators.spell = new Schema<ArmorClassSpell>({
-  value: { type: Number, index: true },
   spell: { type: APIReferenceSchema, index: true },
-  desc: { type: String, index: true },
 });
 
 ArmorClassSchema.discriminators.condition = new Schema<ArmorClassCondition>({
-  value: { type: Number, index: true },
   condition: { type: APIReferenceSchema, index: true },
-  desc: { type: String, index: true },
 });
 
 const LegendaryActionSchema = new Schema<LegendaryAction>({

--- a/src/models/monster/index.ts
+++ b/src/models/monster/index.ts
@@ -58,37 +58,30 @@ const ArmorClassSchema = new Schema<ArmorClass>(
   {
     _id: false,
     type: { type: String, index: true, enum: ['dex', 'natural', 'armor', 'spell', 'condition'] },
+    desc: { type: String, index: true },
+    value: { type: Number, index: true },
   },
   { discriminatorKey: 'type', _id: false }
 );
 
 ArmorClassSchema.discriminators = {};
-ArmorClassSchema.discriminators.dex = new Schema<ArmorClassDex>({
-  _id: false,
-  value: { type: Number, index: true },
-});
+ArmorClassSchema.discriminators.dex = new Schema<ArmorClassDex>({});
 
-ArmorClassSchema.discriminators.natural = new Schema<ArmorClassNatural>({
-  _id: false,
-  value: { type: Number, index: true },
-});
+ArmorClassSchema.discriminators.natural = new Schema<ArmorClassNatural>({});
 
 ArmorClassSchema.discriminators.armor = new Schema<ArmorClassArmor>({
-  _id: false,
   value: { type: Number, index: true },
   armor: { type: [APIReferenceSchema], index: true },
   desc: { type: String, index: true },
 });
 
 ArmorClassSchema.discriminators.spell = new Schema<ArmorClassSpell>({
-  _id: false,
   value: { type: Number, index: true },
   spell: { type: APIReferenceSchema, index: true },
   desc: { type: String, index: true },
 });
 
 ArmorClassSchema.discriminators.condition = new Schema<ArmorClassCondition>({
-  _id: false,
   value: { type: Number, index: true },
   condition: { type: APIReferenceSchema, index: true },
   desc: { type: String, index: true },

--- a/src/models/monster/types.d.ts
+++ b/src/models/monster/types.d.ts
@@ -40,6 +40,7 @@ type ArmorClassDex = {
   _id?: boolean;
   type: 'dex';
   value: number;
+  desc?: string;
 };
 
 type ArmorClassNatural = {

--- a/src/models/monster/types.d.ts
+++ b/src/models/monster/types.d.ts
@@ -29,6 +29,50 @@ type Action = {
   action_options: Choice;
 };
 
+type ArmorClass =
+  | ArmorClassDex
+  | ArmorClassNatural
+  | ArmorClassArmor
+  | ArmorClassSpell
+  | ArmorClassCondition;
+
+type ArmorClassDex = {
+  _id?: boolean;
+  type: 'dex';
+  value: number;
+};
+
+type ArmorClassNatural = {
+  _id?: boolean;
+  type: 'natural';
+  value: number;
+  desc?: string;
+};
+
+type ArmorClassArmor = {
+  _id?: boolean;
+  type: 'armor';
+  value: number;
+  armor?: APIReference[]; // Equipment
+  desc?: string;
+};
+
+type ArmorClassSpell = {
+  _id?: boolean;
+  type: 'spell';
+  value: number;
+  spell: APIReference; // Spell
+  desc?: string;
+};
+
+type ArmorClassCondition = {
+  _id?: boolean;
+  type: 'condition';
+  value: number;
+  condition: APIReference; // Condition
+  desc?: string;
+};
+
 type LegendaryAction = {
   _id?: boolean;
   name: string;
@@ -113,7 +157,7 @@ export type Monster = {
   _id?: mongoose.Types.ObjectId;
   actions?: Action[];
   alignment: string;
-  armor_class: number;
+  armor_class: ArmorClass[];
   challenge_rating: number;
   charisma: number;
   condition_immunities: APIReference[];

--- a/src/swagger/paths/monsters.yml
+++ b/src/swagger/paths/monsters.yml
@@ -98,7 +98,9 @@ monster-index:
                     times: 3
                     type: per day
               alignment: lawful evil
-              armor_class: 17
+              armor_class:
+                - type: natural
+                  value: 17
               challenge_rating: 10
               charisma: 18
               condition_immunities: []

--- a/src/swagger/schemas/monsters.yml
+++ b/src/swagger/schemas/monsters.yml
@@ -9,6 +9,8 @@ monster-armor-class:
           enum: [dex]
         value:
           type: number
+        desc:
+          type: string
     - type: object
       properties:
         type:
@@ -16,6 +18,8 @@ monster-armor-class:
           enum: [natural]
         value:
           type: number
+        desc:
+          type: string
     - type: object
       properties:
         type:

--- a/src/swagger/schemas/monsters.yml
+++ b/src/swagger/schemas/monsters.yml
@@ -1,3 +1,57 @@
+monster-armor-class:
+  description: The armor class of a monster.
+  type: object
+  oneOf:
+    - type: object
+      properties:
+        type:
+          type: string
+          enum: [dex]
+        value:
+          type: number
+    - type: object
+      properties:
+        type:
+          type: string
+          enum: [natural]
+        value:
+          type: number
+    - type: object
+      properties:
+        type:
+          type: string
+          enum: [armor]
+        value:
+          type: number
+        armor:
+          type: array
+          items:
+            $ref: './combined.yml#/APIReference'
+        desc:
+          type: string
+    - type: object
+      properties:
+        type:
+          type: string
+          enum: [spell]
+        value:
+          type: number
+        spell:
+          $ref: './combined.yml#/APIReference'
+        desc:
+          type: string
+    - type: object
+      properties:
+        type:
+          type: string
+          enum: [condition]
+        value:
+          type: number
+        condition:
+          $ref: './combined.yml#/APIReference'
+        desc:
+          type: string
+
 monster-damage:
   description: Damage type and dice associated with a particular attack.
   type: object
@@ -228,7 +282,9 @@ monster-model:
             - unaligned
         armor_class:
           description: 'The difficulty for a player to successfully deal damage to a monster.'
-          type: number
+          type: array
+          items:
+            $ref: '#/monster-armor-class'
         hit_points:
           description: 'The hit points of a monster determine how much damage it is able to take before it can be defeated.'
           type: number


### PR DESCRIPTION
BREAKING CHANGE: Changes the shape of armor_class in monsters

## What does this do?
Changes the shape of armor_class in monsters from a number to:

```typescript
type ArmorClass = (ArmorClassDex | ArmorClassNatural | ArmorClassArmor | ArmorClassSpell | ArmorClassCondition)[];
type ArmorClassDex = {
  type: "dex";
  value: number;
  desc?: string;
};
type ArmorClassNatural = {
  type: "natural";
  value: number;
  desc?: string;
}
type ArmorClassArmor = {
  type: "armor";
  value: number;
  armor?: APIReference[]; // Equipment
  desc?: string;
}
type ArmorClassSpell = {
  type: "spell";
  value: number;
  spell: APIReference; // Spell
  desc?: string;
}
type ArmorClassCondition = {
  type: "condition";
  value: number;
  condition: APIReference; // Condition
  desc?: string;
}
```

## How was it tested?
CI

## Is there a Github issue this is resolving?
<https://github.com/5e-bits/5e-database/issues/280>

## Was any impacted documentation updated to reflect this change?
Heck yeah!

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/208052763-6b5729ba-49a1-497a-9b88-3fce21365945.png)
