### PR TITLE
feat: add monster armor types

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,13 @@ version: '3.8'
 services:
   db:
     image: ghcr.io/5e-bits/5e-database:latest
-    # build: ../5e-database
     ports:
-      - "27017:27017"
+      - '27017:27017'
 
   cache:
     image: redis:6.2.5
     ports:
-      - "6379:6379"
+      - '6379:6379'
 
   api:
     environment:

--- a/src/graphql/resolvers/monsterResolver.ts
+++ b/src/graphql/resolvers/monsterResolver.ts
@@ -5,8 +5,17 @@ import DamageTypeModel from '../../models/damageType/index.js';
 import MonsterModel from '../../models/monster/index.js';
 import ProficiencyModel from '../../models/proficiency/index.js';
 import SpellModel from '../../models/spell/index.js';
+import EquipmentModel from '../../models/equipment/index.js';
 
-import { Monster, ActionUsage, SpecialAbilityUsage } from '../../models/monster/types';
+import {
+  Monster,
+  ActionUsage,
+  SpecialAbilityUsage,
+  ArmorClassNatural,
+  ArmorClassSpell,
+  ArmorClassArmor,
+  ArmorClassCondition,
+} from '../../models/monster/types';
 import { DamageType } from '../../models/damageType/types';
 import { Damage } from '../../models/common/types';
 
@@ -182,6 +191,47 @@ const Monster = {
     }
 
     return actionsToReturn;
+  },
+  armor_class: async (monster: Monster) => {
+    const { armor_class } = monster;
+
+    const armorClassToReturn = [];
+
+    for (const ac of armor_class) {
+      const acTorReturn: any = {
+        type: ac.type.toUpperCase(),
+        value: ac.value,
+        desc: (ac as ArmorClassNatural).desc,
+      };
+
+      if ((ac as ArmorClassSpell).spell) {
+        const spell = await SpellModel.findOne({
+          index: (ac as ArmorClassSpell).spell.index,
+        }).lean();
+
+        acTorReturn.spell = spell;
+      }
+
+      if ((ac as ArmorClassArmor).armor) {
+        const armor = await EquipmentModel.find({
+          index: { $in: (ac as ArmorClassArmor).armor.map(a => a.index) },
+        }).lean();
+
+        acTorReturn.armor = armor;
+      }
+
+      if ((ac as ArmorClassCondition).condition) {
+        const condition = await ConditionModel.findOne({
+          index: (ac as ArmorClassCondition).condition.index,
+        }).lean();
+
+        acTorReturn.condition = condition;
+      }
+
+      armorClassToReturn.push(acTorReturn);
+    }
+
+    return armorClassToReturn;
   },
 };
 

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -654,10 +654,27 @@ type MonsterAction {
   usage: Usage
 }
 
+enum MonsterArmorClassType {
+  DEX
+  NATURAL
+  ARMOR
+  SPELL
+  CONDITION
+}
+
+type MonsterArmorClass {
+  type: MonsterArmorClassType!
+  value: Int!
+  desc: String
+  armor: [Armor!]
+  spell: Spell
+  condition: Condition
+}
+
 type Monster {
   index: String!
   name: String!
-  armor_class: Int!
+  armor_class: [MonsterArmorClass!]!
   desc: String
   actions: [MonsterAction!]
   challenge_rating: Float!

--- a/src/models/monster/index.ts
+++ b/src/models/monster/index.ts
@@ -19,6 +19,7 @@ import {
   SpecialAbility,
   Speed,
   Monster,
+  ArmorClass,
 } from './types';
 
 const ActionOptionSchema = new Schema<ActionOption>({
@@ -129,10 +130,25 @@ const SpeedSchema = new Schema<Speed>({
   walk: { type: String, index: true },
 });
 
+const ArmorClassSchema = new Schema<ArmorClass>({
+  _id: false,
+  type: {
+    type: String,
+    index: true,
+    required: true,
+    enum: ['dex', 'natural', 'armor', 'spell', 'condition'],
+  },
+  value: { type: Number, index: true, required: true },
+  desc: { type: String, index: true },
+  armor: APIReferenceSchema,
+  spell: APIReferenceSchema,
+  condition: APIReferenceSchema,
+});
+
 const Monster = new Schema<Monster>({
   _id: { type: String, select: false },
   actions: [ActionSchema],
-  alignment: { type: String, index: true },
+  alignment: [ArmorClassSchema],
   armor_class: { type: Number, index: true },
   challenge_rating: { type: Number, index: true },
   charisma: { type: Number, index: true },

--- a/src/models/monster/types.d.ts
+++ b/src/models/monster/types.d.ts
@@ -109,11 +109,46 @@ type Speed = {
   walk?: string;
 };
 
+type ArmorClassDex = {
+  type: 'dex';
+  value: number;
+};
+type ArmorClassNatural = {
+  type: 'natural';
+  value: number;
+  desc?: string;
+};
+type ArmorClassArmor = {
+  type: 'armor';
+  value: number;
+  armor: APIReference[]; // Equipment
+  desc?: string;
+};
+type ArmorClassSpell = {
+  type: 'spell';
+  value: number;
+  spell: APIReference; // Spell
+  desc?: string;
+};
+type ArmorClassCondition = {
+  type: 'condition';
+  value: number;
+  condition: APIReference; // Condition
+  desc?: string;
+};
+
+type ArmorClass =
+  | ArmorClassDex
+  | ArmorClassNatural
+  | ArmorClassArmor
+  | ArmorClassSpell
+  | ArmorClassCondition;
+
 export type Monster = {
   _id?: mongoose.Types.ObjectId;
   actions?: Action[];
   alignment: string;
-  armor_class: number;
+  armor_class: ArmorClass[];
   challenge_rating: number;
   charisma: number;
   condition_immunities: APIReference[];

--- a/src/swagger/paths/monsters.yml
+++ b/src/swagger/paths/monsters.yml
@@ -98,7 +98,9 @@ monster-index:
                     times: 3
                     type: per day
               alignment: lawful evil
-              armor_class: 17
+              armor_class:
+                - type: natural
+                  value: 17
               challenge_rating: 10
               charisma: 18
               condition_immunities: []

--- a/src/swagger/schemas/monsters.yml
+++ b/src/swagger/schemas/monsters.yml
@@ -183,6 +183,25 @@ monster-special-ability:
     usage:
       $ref: '#/monster-usage'
 
+monster-armor-class:
+  type: object
+  properties:
+    type:
+      type: string
+      enum: [dex, natural, armor, spell, condition]
+    value:
+      type: number
+    desc:
+      type: string
+    spell:
+      $ref: './combined.yml#/APIReference'
+    armor:
+      type: array
+      items:
+        $ref: './combined.yml#/APIReference'
+    condition:
+      $ref: './combined.yml#/APIReference'
+
 monster-model:
   description: |
     `Monster`
@@ -228,7 +247,9 @@ monster-model:
             - unaligned
         armor_class:
           description: 'The difficulty for a player to successfully deal damage to a monster.'
-          type: number
+          type: array
+          items:
+            $ref: '#/monster-armor-class'
         hit_points:
           description: 'The hit points of a monster determine how much damage it is able to take before it can be defeated.'
           type: number


### PR DESCRIPTION
BREAKING CHANGE

## What does this do?
Updates the API to be in parity with the recent [database change that added monster armor types](https://github.com/5e-bits/5e-database/pull/518).

## How was it tested?
Didn't get to test it yet as I'm having problems with docker-compose

## Is there a Github issue this is resolving?
[Yes](https://github.com/5e-bits/5e-database/issues/280)

## Was any impacted documentation updated to reflect this change?
Yes

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
