### PR TITLE
feat: Query equipment-category/weapons by property

### DIFF
--- a/src/controllers/api/equipmentCategoryController.ts
+++ b/src/controllers/api/equipmentCategoryController.ts
@@ -1,4 +1,41 @@
 import EquipmentCategory from '../../models/equipmentCategory/index.js';
+import Equipment from '../../models/equipment/index.js';
 import SimpleController from '../simpleController.js';
+import { Request, Response, NextFunction } from 'express';
+import { APIReference } from '../../models/common/types.js';
 
-export default new SimpleController(EquipmentCategory);
+export const index = async (req: Request, res: Response, next: NextFunction) => {
+  const instantiatedSimpleController = new SimpleController(EquipmentCategory);
+  const indexResult = instantiatedSimpleController.index(req, res, next);
+  return indexResult;
+};
+
+export const show = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const requestedEquipmentCategory = await EquipmentCategory.findOne({
+      index: req.params.index,
+    });
+    if (!requestedEquipmentCategory) return next();
+    if (req.query.property !== undefined) {
+      const weaponData = await Equipment.find({
+        'equipment_category.index': req.params.index,
+      })
+        .where('properties')
+        .elemMatch({ index: req.query.property });
+
+      const filteredEquipmentArray = requestedEquipmentCategory.equipment.filter(function(
+        weaponApiReference
+      ) {
+        return weaponData.some(function checkforMatch(weaponPropertyApiReference) {
+          return weaponApiReference.index === weaponPropertyApiReference.index;
+        });
+      });
+      requestedEquipmentCategory.equipment = filteredEquipmentArray as APIReference[];
+      return res.status(200).json(requestedEquipmentCategory);
+    } else {
+      return res.status(200).json(requestedEquipmentCategory);
+    }
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/controllers/api/equipmentCategoryController.ts
+++ b/src/controllers/api/equipmentCategoryController.ts
@@ -23,13 +23,13 @@ export const show = async (req: Request, res: Response, next: NextFunction) => {
         .where('properties')
         .elemMatch({ index: req.query.property });
 
-      const filteredEquipmentArray = requestedEquipmentCategory.equipment.filter(function(
-        weaponApiReference
-      ) {
-        return weaponData.some(function checkforMatch(weaponPropertyApiReference) {
-          return weaponApiReference.index === weaponPropertyApiReference.index;
-        });
-      });
+      const filteredEquipmentArray = requestedEquipmentCategory.equipment.filter(
+        weaponApiReference => {
+          return weaponData.some(weaponPropertyApiReference => {
+            return weaponApiReference.index === weaponPropertyApiReference.index;
+          });
+        }
+      );
       requestedEquipmentCategory.equipment = filteredEquipmentArray as APIReference[];
       return res.status(200).json(requestedEquipmentCategory);
     } else {

--- a/src/routes/api/equipmentCategories.ts
+++ b/src/routes/api/equipmentCategories.ts
@@ -1,15 +1,15 @@
 import * as express from 'express';
 
-import EquipmentCategoryController from '../../controllers/api/equipmentCategoryController.js';
+import { index, show } from '../../controllers/api/equipmentCategoryController.js';
 
 const router = express.Router();
 
 router.get('/', function(req, res, next) {
-  EquipmentCategoryController.index(req, res, next);
+  index(req, res, next);
 });
 
 router.get('/:index', function(req, res, next) {
-  EquipmentCategoryController.show(req, res, next);
+  show(req, res, next);
 });
 
 export default router;

--- a/src/swagger/parameters/combined.yml
+++ b/src/swagger/parameters/combined.yml
@@ -1,56 +1,60 @@
 ability-score-index:
-  $ref: "./path/ability-scores.yml"
+  $ref: './path/ability-scores.yml'
 alignment-index:
-  $ref: "./path/alignments.yml"
+  $ref: './path/alignments.yml'
 language-index:
-  $ref: "./path/languages.yml"
+  $ref: './path/languages.yml'
 proficiency-index:
-  $ref: "./path/proficiencies.yml"
+  $ref: './path/proficiencies.yml'
 skill-index:
-  $ref: "./path/skills.yml"
+  $ref: './path/skills.yml'
 class-index:
-  $ref: "./path/classes.yml#/class-index"
+  $ref: './path/classes.yml#/class-index'
 background-index:
-  $ref: "./path/backgrounds.yml"
+  $ref: './path/backgrounds.yml'
 weapon-property-index:
-  $ref: "./path/weapon-properties.yml"
+  $ref: './path/weapon-properties.yml'
 class-level:
-  $ref: "./path/classes.yml#/class-level"
+  $ref: './path/classes.yml#/class-level'
 spell-level:
-  $ref: "./path/classes.yml#/spell-level"
+  $ref: './path/classes.yml#/spell-level'
 condition-index:
-  $ref: "./path/conditions.yml"
+  $ref: './path/conditions.yml'
 damage-type-index:
-  $ref: "./path/damage-types.yml"
+  $ref: './path/damage-types.yml'
 magic-school-index:
-  $ref: "./path/magic-schools.yml"
+  $ref: './path/magic-schools.yml'
 equipment-index:
-  $ref: "./path/equipment.yml"
+  $ref: './path/equipment.yml'
 feature-index:
-  $ref: "./path/features.yml"
+  $ref: './path/features.yml'
 rule-index:
-  $ref: "./path/rules.yml"
+  $ref: './path/rules.yml'
 rule-section-index:
-  $ref: "./path/rule-sections.yml"
+  $ref: './path/rule-sections.yml'
 race-index:
-  $ref: "./path/races.yml"
+  $ref: './path/races.yml'
 subclass-index:
-  $ref: "./path/subclasses.yml"
+  $ref: './path/subclasses.yml'
 subrace-index:
-  $ref: "./path/subraces.yml"
+  $ref: './path/subraces.yml'
 trait-index:
-  $ref: "./path/traits.yml"
+  $ref: './path/traits.yml'
 monster-index:
-  $ref: "./path/monsters.yml"
+  $ref: './path/monsters.yml'
 spell-index:
-  $ref: "./path/spells.yml"
+  $ref: './path/spells.yml'
 level-filter:
-  $ref: "./query/spells.yml#/level-filter"
+  $ref: './query/spells.yml#/level-filter'
 school-filter:
-  $ref: "./query/spells.yml#/school-filter"
+  $ref: './query/spells.yml#/school-filter'
 challenge-rating-filter:
-  $ref: "./query/monsters.yml#/challenge-rating-filter"
+  $ref: './query/monsters.yml#/challenge-rating-filter'
 levels-subclass-filter:
-  $ref: "./query/classes.yml#/levels-subclass-filter"
+  $ref: './query/classes.yml#/levels-subclass-filter'
 base-endpoint-index:
-  $ref: "./path/common.yml"
+  $ref: './path/common.yml'
+weapon-property-filter:
+  $ref: './query/equipment-categories.yml#/weapon-property-filter'
+equipment-category-index:
+  $ref: './path/equipment-categories.yml'

--- a/src/swagger/parameters/path/equipment-categories.yml
+++ b/src/swagger/parameters/path/equipment-categories.yml
@@ -1,0 +1,10 @@
+name: index
+in: path
+required: true
+description: |
+  The `index` of the equipment category score to get.
+
+  Available values can be found in the resource list for this endpoint.
+schema:
+  type: string
+  example: 'waterborne-vehicles'

--- a/src/swagger/parameters/query/equipment-categories.yml
+++ b/src/swagger/parameters/query/equipment-categories.yml
@@ -1,0 +1,20 @@
+weapon-property-filter:
+  name: property
+  in: query
+  description: |
+    The weapon `property` used to filter equipment category weapon results.
+  schema:
+    type: string
+    enum:
+      - ammunition
+      - finesse
+      - heavy
+      - light
+      - loading
+      - reach
+      - special
+      - thrown
+      - two-handed
+      - versatile
+      - monk
+    example: finesse

--- a/src/swagger/paths/combined.yml
+++ b/src/swagger/paths/combined.yml
@@ -1,94 +1,94 @@
 base:
-  $ref: "./common.yml#/api-base"
+  $ref: './common.yml#/api-base'
 list:
-  $ref: "./common.yml#/resource-list"
+  $ref: './common.yml#/resource-list'
 ability-scores:
-  $ref: "./ability-scores.yml"
+  $ref: './ability-scores.yml'
 alignments:
-  $ref: "./alignments.yml"
+  $ref: './alignments.yml'
 backgrounds:
-  $ref: "./backgrounds.yml"
+  $ref: './backgrounds.yml'
 classes:
-  $ref: "./classes.yml#/class-path"
+  $ref: './classes.yml#/class-path'
 class-subclass:
-  $ref: "./classes.yml#/class-subclass-path"
+  $ref: './classes.yml#/class-subclass-path'
 class-spells:
-  $ref: "./classes.yml#/class-spells-path"
+  $ref: './classes.yml#/class-spells-path'
 class-spellcasting:
-  $ref: "./classes.yml#/class-spellcasting-path"
+  $ref: './classes.yml#/class-spellcasting-path'
 class-features:
-  $ref: "./classes.yml#/class-features-path"
+  $ref: './classes.yml#/class-features-path'
 class-proficiencies:
-  $ref: "./classes.yml#/class-proficiencies-path"
+  $ref: './classes.yml#/class-proficiencies-path'
 class-multi-classing:
-  $ref: "./classes.yml#/class-multi-classing-path"
+  $ref: './classes.yml#/class-multi-classing-path'
 class-levels:
-  $ref: "./classes.yml#/class-levels-path"
+  $ref: './classes.yml#/class-levels-path'
 class-level:
-  $ref: "./classes.yml#/class-level-path"
+  $ref: './classes.yml#/class-level-path'
 class-level-features:
-  $ref: "./classes.yml#/class-level-features-path"
+  $ref: './classes.yml#/class-level-features-path'
 class-spell-level-spells:
-  $ref: "./classes.yml#/class-spell-level-spells-path"
+  $ref: './classes.yml#/class-spell-level-spells-path'
 conditions:
-  $ref: "./conditions.yml"
+  $ref: './conditions.yml'
 damage-types:
-  $ref: "./damage-types.yml"
+  $ref: './damage-types.yml'
 equipment:
-  $ref: "./equipment.yml"
+  $ref: './equipment.yml'
 equipment-categories:
-  $ref: "./equipment-categories.yml"
+  $ref: './equipment-categories.yml#/equipment-category-index'
 feats:
-  $ref: "./feats.yml"
+  $ref: './feats.yml'
 features:
-  $ref: "./features.yml"
+  $ref: './features.yml'
 languages:
-  $ref: "./languages.yml"
+  $ref: './languages.yml'
 magic-items:
-  $ref: "./magic-items.yml"
+  $ref: './magic-items.yml'
 magic-schools:
-  $ref: "./magic-schools.yml"
+  $ref: './magic-schools.yml'
 monsters:
-  $ref: "./monsters.yml#/monster-resource-list"
+  $ref: './monsters.yml#/monster-resource-list'
 monster:
-  $ref: "./monsters.yml#/monster-index"
+  $ref: './monsters.yml#/monster-index'
 proficiencies:
-  $ref: "./proficiencies.yml"
+  $ref: './proficiencies.yml'
 races:
-  $ref: "./races.yml#/race-path"
+  $ref: './races.yml#/race-path'
 race-subraces:
-  $ref: "./races.yml#/race-subraces-path"
+  $ref: './races.yml#/race-subraces-path'
 race-proficiencies:
-  $ref: "./races.yml#/race-proficiencies-path"
+  $ref: './races.yml#/race-proficiencies-path'
 race-traits:
-  $ref: "./races.yml#/race-traits-path"
+  $ref: './races.yml#/race-traits-path'
 rule-sections:
-  $ref: "./rule-sections.yml"
+  $ref: './rule-sections.yml'
 rules:
-  $ref: "./rules.yml"
+  $ref: './rules.yml'
 skills:
-  $ref: "./skills.yml"
+  $ref: './skills.yml'
 spells:
-  $ref: "./spells.yml#/spells-resource-list"
+  $ref: './spells.yml#/spells-resource-list'
 spell:
-  $ref: "./spells.yml#/spell-by-index"
+  $ref: './spells.yml#/spell-by-index'
 subclasses:
-  $ref: "./subclasses.yml#/subclass-path"
+  $ref: './subclasses.yml#/subclass-path'
 subclass-features:
-  $ref: "./subclasses.yml#/subclass-features-path"
+  $ref: './subclasses.yml#/subclass-features-path'
 subclass-levels:
-  $ref: "./subclasses.yml#/subclass-levels-path"
+  $ref: './subclasses.yml#/subclass-levels-path'
 subclass-level:
-  $ref: "./subclasses.yml#/subclass-level-path"
+  $ref: './subclasses.yml#/subclass-level-path'
 subclass-level-features:
-  $ref: "./subclasses.yml#/subclass-level-features-path"
+  $ref: './subclasses.yml#/subclass-level-features-path'
 subraces:
-  $ref: "./subraces.yml#/subraces-path"
+  $ref: './subraces.yml#/subraces-path'
 subrace-proficiencies:
-  $ref: "./subraces.yml#/subrace-proficiencies-path"
+  $ref: './subraces.yml#/subrace-proficiencies-path'
 subrace-traits:
-  $ref: "./subraces.yml#/subrace-traits-path"
+  $ref: './subraces.yml#/subrace-traits-path'
 traits:
-  $ref: "./traits.yml"
+  $ref: './traits.yml'
 weapon-properties:
-  $ref: "./weapon-properties.yml"
+  $ref: './weapon-properties.yml'

--- a/src/swagger/paths/equipment-categories.yml
+++ b/src/swagger/paths/equipment-categories.yml
@@ -1,46 +1,39 @@
-get:
-  summary: Get an equipment category by index.
-  description: These are the categories that various equipment fall under.
-  tags:
-    - Equipment
-  parameters:
-    - name: index
-      in: path
-      required: true
-      description: |
-        The `index` of the equipment category score to get.
-
-        Available values can be found in the resource list for this endpoint.
-      schema:
-        type: string
-      example: "waterborne-vehicles"
-  responses:
-    "200":
-      description: OK
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/combined.yml#/EquipmentCategory"
-          example:
-            index: waterborne-vehicles
-            name: Waterborne Vehicles
-            url: "/api/equipment-categories/waterborne-vehicles"
-            equipment:
-              - index: galley
-                name: Galley
-                url: "/api/equipment/galley"
-              - index: keelboat
-                name: Keelboat
-                url: "/api/equipment/keelboat"
-              - index: longship
-                name: Longship
-                url: "/api/equipment/longship"
-              - index: rowboat
-                name: Rowboat
-                url: "/api/equipment/rowboat"
-              - index: sailing-ship
-                name: Sailing ship
-                url: "/api/equipment/sailing-ship"
-              - index: warship
-                name: Warship
-                url: "/api/equipment/warship"
+equipment-category-index:
+  get:
+    summary: Get an equipment category by index.
+    description: These are the categories that various equipment fall under.
+    tags:
+      - Equipment
+    parameters:
+      - $ref: '../parameters/combined.yml#/equipment-category-index'
+      - $ref: '../parameters/combined.yml#/weapon-property-filter'
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/combined.yml#/EquipmentCategory'
+            example:
+              index: waterborne-vehicles
+              name: Waterborne Vehicles
+              url: '/api/equipment-categories/waterborne-vehicles'
+              equipment:
+                - index: galley
+                  name: Galley
+                  url: '/api/equipment/galley'
+                - index: keelboat
+                  name: Keelboat
+                  url: '/api/equipment/keelboat'
+                - index: longship
+                  name: Longship
+                  url: '/api/equipment/longship'
+                - index: rowboat
+                  name: Rowboat
+                  url: '/api/equipment/rowboat'
+                - index: sailing-ship
+                  name: Sailing ship
+                  url: '/api/equipment/sailing-ship'
+                - index: warship
+                  name: Warship
+                  url: '/api/equipment/warship'

--- a/src/tests/controllers/api/equipmentCategoryController.test.ts
+++ b/src/tests/controllers/api/equipmentCategoryController.test.ts
@@ -3,7 +3,7 @@ import { createRequest, createResponse } from 'node-mocks-http';
 import { mockNext } from '../../support/requestHelpers.js';
 
 import EquipmentCategory from '../../../models/equipmentCategory/index.js';
-import EquipmentCategoryController from '../../../controllers/api/equipmentCategoryController.js';
+import { index, show } from '../../../controllers/api/equipmentCategoryController.js';
 
 beforeEach(() => {
   mockingoose.resetAll();
@@ -33,7 +33,7 @@ describe('index', () => {
     const response = createResponse();
     mockingoose(EquipmentCategory).toReturn(findDoc, 'find');
 
-    await EquipmentCategoryController.index(request, response, mockNext);
+    await index(request, response, mockNext);
 
     expect(response.statusCode).toBe(200);
   });
@@ -44,7 +44,7 @@ describe('index', () => {
       const error = new Error('Something went wrong');
       mockingoose(EquipmentCategory).toReturn(error, 'find');
 
-      await EquipmentCategoryController.index(request, response, mockNext);
+      await index(request, response, mockNext);
 
       expect(response.statusCode).toBe(200);
       expect(response._getData()).toStrictEqual('');
@@ -67,7 +67,7 @@ describe('show', () => {
     const response = createResponse();
     mockingoose(EquipmentCategory).toReturn(findOneDoc, 'findOne');
 
-    await EquipmentCategoryController.show(request, response, mockNext);
+    await show(request, response, mockNext);
 
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response._getData())).toStrictEqual(expect.objectContaining(showParams));
@@ -80,7 +80,7 @@ describe('show', () => {
 
       const invalidShowParams = { index: 'abcd' };
       const invalidRequest = createRequest({ params: invalidShowParams });
-      await EquipmentCategoryController.show(invalidRequest, response, mockNext);
+      await show(invalidRequest, response, mockNext);
 
       expect(response.statusCode).toBe(200);
       expect(response._getData()).toStrictEqual('');
@@ -94,7 +94,7 @@ describe('show', () => {
       const error = new Error('Something went wrong');
       mockingoose(EquipmentCategory).toReturn(error, 'findOne');
 
-      await EquipmentCategoryController.show(request, response, mockNext);
+      await show(request, response, mockNext);
 
       expect(response.statusCode).toBe(200);
       expect(response._getData()).toStrictEqual('');


### PR DESCRIPTION
## What does this do?
On the equipment-categories route, one can now filter weapons by weapon properties. 

## How was it tested?
Manually tested various http requests for equipment-categories on Postman successfully. Followed swagger README instructions to set up local development environment which ran successfully after adding new openapi documentation. 

## Is there a Github issue this is resolving?
Yes, this resolves issue #232 

## Was any impacted documentation updated to reflect this change?
Yes, I updated the swagger documentation according to the guidelines found in the swagger README. 

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
