### PR TITLE
feat: Add magic item attunement, wielding, and activation rules

### DIFF
--- a/src/swagger/parameters/path/rule-sections.yml
+++ b/src/swagger/parameters/path/rule-sections.yml
@@ -9,7 +9,9 @@ schema:
     - ability-checks
     - ability-scores-and-modifiers
     - actions-in-combat
+    - activating-an-item
     - advantage-and-disadvantage
+    - attunement
     - between-adventures
     - casting-a-spell
     - cover
@@ -35,5 +37,6 @@ schema:
     - traps
     - underwater-combat
     - using-each-ability
+    - wearing-and-wielding-items
     - what-is-a-spell
   example: traps


### PR DESCRIPTION
## What does this do?

SRD 5.1 added magic item attunement, wearing/wielding, and activation rules that were omitted from SRD 5.0. This adds them as rule-sections.

5e-bits/5e-database#527

## How was it tested?

:rotating_light:  After confirming that I can build 5e-database and view the changes, I tried following the README instructions to build the API and database locally:

```diff
 services:
   db:
-    image: ghcr.io/5e-bits/5e-database:latest
-    # build: ../5e-database
+    # image: ghcr.io/5e-bits/5e-database:latest
+    build: ../5e-database
     ports:
       - "27017:27017"
```

```
sudo docker-compose up --build
```

The branches of both repos are set to the corresponding changes. There are no errors, but the changes don't appear in the local API.

## Is there a Github issue this is resolving?

No.

## Was any impacted documentation updated to reflect this change?

Yes; this is only a documentation change.

## Here's a fun image for your troubles

![random photo - update me](https://preview.redd.it/d3nbpckaxdo61.jpg?auto=webp&s=5dcf8bc84cb80d230791693690ae4064d5ab4979)
