### PR TITLE
feat: Add Subraces

### DIFF
--- a/src/swagger/parameters/path/subraces.yml
+++ b/src/swagger/parameters/path/subraces.yml
@@ -8,6 +8,7 @@ schema:
   enum:
     - high-elf
     - wood-elf
+    - dark-elf
     - hill-dwarf
     - mountain-dwarf
     - lightfoot-halfling

--- a/src/swagger/parameters/path/subraces.yml
+++ b/src/swagger/parameters/path/subraces.yml
@@ -8,6 +8,7 @@ schema:
   enum:
     - high-elf
     - hill-dwarf
+    - mountain-dwarf
     - lightfoot-halfling
     - rock-gnome
   example: hill-dwarf

--- a/src/swagger/parameters/path/subraces.yml
+++ b/src/swagger/parameters/path/subraces.yml
@@ -14,4 +14,5 @@ schema:
     - lightfoot-halfling
     - stout-halfling
     - rock-gnome
+    - forest-gnome
   example: hill-dwarf

--- a/src/swagger/parameters/path/subraces.yml
+++ b/src/swagger/parameters/path/subraces.yml
@@ -12,5 +12,6 @@ schema:
     - hill-dwarf
     - mountain-dwarf
     - lightfoot-halfling
+    - stout-halfling
     - rock-gnome
   example: hill-dwarf

--- a/src/swagger/parameters/path/subraces.yml
+++ b/src/swagger/parameters/path/subraces.yml
@@ -7,6 +7,7 @@ schema:
   type: string
   enum:
     - high-elf
+    - wood-elf
     - hill-dwarf
     - mountain-dwarf
     - lightfoot-halfling

--- a/src/swagger/parameters/path/traits.yml
+++ b/src/swagger/parameters/path/traits.yml
@@ -27,6 +27,7 @@ schema:
     - elf-weapon-training
     - extra-language
     - fey-ancestry
+    - fleet-of-foot
     - gnome-cunning
     - halfling-nimbleness
     - hellish-resistance
@@ -34,6 +35,7 @@ schema:
     - infernal-legacy
     - keen-senses
     - lucky
+    - mask-of-wild
     - menacing
     - naturally-stealthy
     - relentless-endurance

--- a/src/swagger/parameters/path/traits.yml
+++ b/src/swagger/parameters/path/traits.yml
@@ -43,6 +43,7 @@ schema:
     - savage-attacks
     - skill-versatility
     - stonecunning
+    - stout-resilience
     - sunlight-sensitivity
     - superior-darkvision
     - tinker

--- a/src/swagger/parameters/path/traits.yml
+++ b/src/swagger/parameters/path/traits.yml
@@ -21,6 +21,7 @@ schema:
     - draconic-ancestry-red
     - draconic-ancestry-silver
     - draconic-ancestry-white
+    - drow-magic
     - dwarven-combat-training
     - dwarven-resilience
     - dwarven-toughness
@@ -42,6 +43,8 @@ schema:
     - savage-attacks
     - skill-versatility
     - stonecunning
+    - sunlight-sensitivity
+    - superior-darkvision
     - tinker
     - tool-proficiency
     - trance

--- a/src/tests/controllers/api/raceController.test.ts
+++ b/src/tests/controllers/api/raceController.test.ts
@@ -114,6 +114,11 @@ describe('showSubracesForRace', () => {
       name: 'High Elf',
       url: '/api/subraces/high-elf',
     },
+    {
+      index: 'wood-elf',
+      name: 'Wood Elf',
+      url: '/api/subraces/wood-elf',
+    },
   ];
   const showParams = { index: 'dragonborn' };
   const request = createRequest({ params: showParams });

--- a/src/tests/controllers/api/raceController.test.ts
+++ b/src/tests/controllers/api/raceController.test.ts
@@ -119,6 +119,11 @@ describe('showSubracesForRace', () => {
       name: 'Wood Elf',
       url: '/api/subraces/wood-elf',
     },
+    {
+      index: 'dark-elf',
+      name: 'Dark Elf',
+      url: '/api/subraces/dark-elf',
+    },
   ];
   const showParams = { index: 'dragonborn' };
   const request = createRequest({ params: showParams });

--- a/src/tests/controllers/api/subraceController.test.ts
+++ b/src/tests/controllers/api/subraceController.test.ts
@@ -20,6 +20,11 @@ describe('index', () => {
       url: '/api/subraces/high-elf',
     },
     {
+      index: 'wood-elf',
+      name: 'Wood Elf',
+      url: '/api/subraces/wood-elf',
+    },
+    {
       index: 'hill-dwarf',
       name: 'Hill Dwarf',
       url: '/api/subraces/hill-dwarf',

--- a/src/tests/controllers/api/subraceController.test.ts
+++ b/src/tests/controllers/api/subraceController.test.ts
@@ -25,6 +25,11 @@ describe('index', () => {
       url: '/api/subraces/hill-dwarf',
     },
     {
+      index: 'mountain-dwarf',
+      name: 'Mountain Dwarf',
+      url: '/api/subraces/mountain-dwarf',
+    },
+    {
       index: 'lightfoot-halfling',
       name: 'Lightfoot Halfling',
       url: '/api/subraces/lightfoot-halfling',

--- a/src/tests/controllers/api/subraceController.test.ts
+++ b/src/tests/controllers/api/subraceController.test.ts
@@ -45,6 +45,11 @@ describe('index', () => {
       url: '/api/subraces/lightfoot-halfling',
     },
     {
+      index: 'stout-halfling',
+      name: 'Stout Halfling',
+      url: '/api/subraces/stout-halfling',
+    },
+    {
       index: 'rock-gnome',
       name: 'Rock Gnome',
       url: '/api/subraces/rock-gnome',

--- a/src/tests/controllers/api/subraceController.test.ts
+++ b/src/tests/controllers/api/subraceController.test.ts
@@ -54,6 +54,11 @@ describe('index', () => {
       name: 'Rock Gnome',
       url: '/api/subraces/rock-gnome',
     },
+    {
+      index: 'forest-gnome',
+      name: 'Forest Gnome',
+      url: '/api/subraces/forest-gnome',
+    },
   ];
   const request = createRequest({ query: {} });
 

--- a/src/tests/controllers/api/subraceController.test.ts
+++ b/src/tests/controllers/api/subraceController.test.ts
@@ -25,6 +25,11 @@ describe('index', () => {
       url: '/api/subraces/wood-elf',
     },
     {
+      index: 'dark-elf',
+      name: 'Dark Elf',
+      url: '/api/subraces/dark-elf',
+    },
+    {
       index: 'hill-dwarf',
       name: 'Hill Dwarf',
       url: '/api/subraces/hill-dwarf',


### PR DESCRIPTION
## What does this do?
Add the following subraces with associated traits and proficiencies:

- Mountain Dwarf
- Wood Elf
- Dark Elf
- Stout Halfling
- Forest Gnome

## How was it tested?
Per README:

1. Run local Docker image:
```
docker build -t 5e-database .
docker run -i -t 5e-database:latest
```

2. Build with Docker:
```
docker-compose up --build
```

3. Test response at `localhost:3000`
## Is there a Github issue this is resolving?
No

## Was any impacted documentation updated to reflect this change?
Related DB PR: https://github.com/5e-bits/5e-database/pull/532

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/id/29/400/200)
