### PR TITLE
fix: remove circular references from monster swagger docs

### DIFF
--- a/src/swagger/schemas/combined.yml
+++ b/src/swagger/schemas/combined.yml
@@ -86,6 +86,28 @@ RuleSection:
   $ref: './rules.yml#/rule-section-model'
 Monster:
   $ref: './monsters.yml#/monster-model'
+MonsterAbility:
+  $ref: './monsters-common.yml#/monster-ability-model'
+MonsterAction:
+  $ref: './monsters-common.yml#/monster-action-model'
+MonsterArmorClass:
+  $ref: './monsters-common.yml#/monster-armor-class-model'
+MonsterAttack:
+  $ref: './monsters-common.yml#/monster-attack-model'
+MonsterMultiAttackAction:
+  $ref: './monsters-common.yml#/monster-multi-attack-action-model'
+MonsterProficiency:
+  $ref: './monsters-common.yml#/monster-proficiency-model'
+MonsterSense:
+  $ref: './monsters-common.yml#/monster-sense-model'
+MonsterSpecialAbility:
+  $ref: './monsters-common.yml#/monster-special-ability-model'
+MonsterSpell:
+  $ref: './monsters-common.yml#/monster-spell-model'
+MonsterSpellcasting:
+  $ref: './monsters-common.yml#/monster-spellcasting-model'
+MonsterUsage:
+  $ref: './monsters-common.yml#/monster-usage-model'
 SpellPrerequisite:
   $ref: './subclass.yml#/spell-prerequisite'
 error-response:

--- a/src/swagger/schemas/monsters-common.yml
+++ b/src/swagger/schemas/monsters-common.yml
@@ -1,0 +1,231 @@
+monster-attack-model:
+  type: object
+  properties:
+    name:
+      type: string
+    dc:
+      $ref: './combined.yml#/DC'
+    damage:
+      $ref: './combined.yml#/Damage'
+
+monster-ability-model:
+  description: |
+    `Monster Ability`
+  type: object
+  properties:
+    charisma:
+      description: "A monster's ability to charm or intimidate a player."
+      type: number
+    constitution:
+      description: How sturdy a monster is."
+      type: number
+    dexterity:
+      description: "The monster's ability for swift movement or stealth"
+      type: number
+    intelligence:
+      description: "The monster's ability to outsmart a player."
+      type: number
+    strength:
+      description: 'How hard a monster can hit a player.'
+      type: number
+    wisdom:
+      description: "A monster's ability to ascertain the player's plan."
+      type: number
+
+monster-action-model:
+  description: Action available to a `Monster` in addition to the standard creature actions.
+  type: object
+  properties:
+    name:
+      type: string
+    desc:
+      type: string
+    action_options:
+      $ref: './combined.yml#/Choice'
+    actions:
+      type: array
+      items:
+        $ref: './combined.yml#/MonsterMultiAttackAction'
+    options:
+      $ref: './combined.yml#/Choice'
+    multiattack_type:
+      type: string
+    attack_bonus:
+      type: number
+    dc:
+      $ref: './combined.yml#/DC'
+    attacks:
+      type: array
+      items:
+        $ref: './combined.yml#/MonsterAttack'
+    damage:
+      type: array
+      items:
+        $ref: './combined.yml#/Damage'
+
+monster-armor-class-model:
+  description: The armor class of a monster.
+  type: object
+  oneOf:
+    - type: object
+      properties:
+        type:
+          type: string
+          enum: [dex]
+        value:
+          type: number
+        desc:
+          type: string
+    - type: object
+      properties:
+        type:
+          type: string
+          enum: [natural]
+        value:
+          type: number
+        desc:
+          type: string
+    - type: object
+      properties:
+        type:
+          type: string
+          enum: [armor]
+        value:
+          type: number
+        armor:
+          type: array
+          items:
+            $ref: './combined.yml#/APIReference'
+        desc:
+          type: string
+    - type: object
+      properties:
+        type:
+          type: string
+          enum: [spell]
+        value:
+          type: number
+        spell:
+          $ref: './combined.yml#/APIReference'
+        desc:
+          type: string
+    - type: object
+      properties:
+        type:
+          type: string
+          enum: [condition]
+        value:
+          type: number
+        condition:
+          $ref: './combined.yml#/APIReference'
+        desc:
+          type: string
+
+monster-multi-attack-action-model:
+  type: object
+  properties:
+    action_name:
+      type: string
+    count:
+      type: number
+    type:
+      type: string
+      enum: [melee, ranged, ability, magic]
+
+monster-proficiency-model:
+  type: object
+  properties:
+    value:
+      type: number
+    proficiency:
+      $ref: './combined.yml#/APIReference'
+
+monster-sense-model:
+  type: object
+  properties:
+    passive_perception:
+      description: The monster's passive perception (wisdom) score.
+      type: number
+    blindsight:
+      description: A monster with blindsight can perceive its surroundings without relying on sight, within a specific radius.
+      type: string
+    darkvision:
+      description: A monster with darkvision can see in the dark within a specific radius.
+      type: string
+    tremorsense:
+      description: A monster with tremorsense can detect and pinpoint the origin of vibrations within a specific radius, provided that the monster and the source of the vibrations are in contact with the same ground or substance.
+      type: string
+    truesight:
+      description: A monster with truesight can, out to a specific range, see in normal and magical darkness, see invisible creatures and objects, automatically detect visual illusions and succeed on saving throws against them, and perceive the original form of a shapechanger or a creature that is transformed by magic. Furthermore, the monster can see into the Ethereal Plane within the same range.
+      type: string
+
+monster-special-ability-model:
+  type: object
+  properties:
+    name:
+      type: string
+    desc:
+      type: string
+    attack_bonus:
+      type: number
+    damage:
+      $ref: './combined.yml#/Damage'
+    dc:
+      $ref: './combined.yml#/DC'
+    spellcasting:
+      $ref: './combined.yml#/MonsterSpellcasting'
+    usage:
+      $ref: './combined.yml#/MonsterUsage'
+
+monster-spell-model:
+  type: object
+  properties:
+    name:
+      type: string
+    level:
+      type: number
+    url:
+      type: string
+    usage:
+      $ref: './combined.yml#/MonsterUsage'
+
+monster-spellcasting-model:
+  type: object
+  properties:
+    ability:
+      $ref: './combined.yml#/APIReference'
+    dc:
+      type: number
+    modifier:
+      type: number
+    components_required:
+      type: array
+      items:
+        type: string
+    school:
+      type: string
+    slots:
+      type: object
+      additionalProperties:
+        type: number
+    spells:
+      type: array
+      items:
+        $ref: './combined.yml#/MonsterSpell'
+
+monster-usage-model:
+  type: object
+  properties:
+    type:
+      type: string
+      enum:
+        - at will
+        - per day
+        - recharge after rest
+        - recharge on roll
+    rest_types:
+      type: array
+      items:
+        type: string
+    times:
+      type: number

--- a/src/swagger/schemas/monsters.yml
+++ b/src/swagger/schemas/monsters.yml
@@ -1,253 +1,10 @@
-monster-armor-class:
-  description: The armor class of a monster.
-  type: object
-  oneOf:
-    - type: object
-      properties:
-        type:
-          type: string
-          enum: [dex]
-        value:
-          type: number
-        desc:
-          type: string
-    - type: object
-      properties:
-        type:
-          type: string
-          enum: [natural]
-        value:
-          type: number
-        desc:
-          type: string
-    - type: object
-      properties:
-        type:
-          type: string
-          enum: [armor]
-        value:
-          type: number
-        armor:
-          type: array
-          items:
-            $ref: './combined.yml#/APIReference'
-        desc:
-          type: string
-    - type: object
-      properties:
-        type:
-          type: string
-          enum: [spell]
-        value:
-          type: number
-        spell:
-          $ref: './combined.yml#/APIReference'
-        desc:
-          type: string
-    - type: object
-      properties:
-        type:
-          type: string
-          enum: [condition]
-        value:
-          type: number
-        condition:
-          $ref: './combined.yml#/APIReference'
-        desc:
-          type: string
-
-monster-damage:
-  description: Damage type and dice associated with a particular attack.
-  type: object
-  properties:
-    damage_type:
-      $ref: './combined.yml#/APIReference'
-    damage_dice:
-      type: string
-      pattern: '^\d+d\d+(\+\d+)?$'
-      example: 2d6+5
-
-monster-attack:
-  type: object
-  properties:
-    name:
-      type: string
-    dc:
-      $ref: './combined.yml#/DC'
-    damage:
-      $ref: '#/monster-damage'
-
-multiattack-action:
-  type: object
-  properties:
-    action_name:
-      type: string
-    count:
-      type: number
-    type:
-      type: string
-      enum: [melee, ranged, ability, magic]
-
-monster-action:
-  description: Action available to a `Monster` in addition to the standard creature actions.
-  type: object
-  properties:
-    name:
-      type: string
-    desc:
-      type: string
-    action_options:
-      $ref: './combined.yml#/Choice'
-    actions:
-      type: array
-      items:
-        $ref: '#/multiattack-action'
-    options:
-      $ref: './combined.yml#/Choice'
-    multiattack_type:
-      type: string
-    attack_bonus:
-      type: number
-    dc:
-      $ref: './combined.yml#/DC'
-    attacks:
-      type: array
-      items:
-        $ref: '#/monster-attack'
-    damage:
-      type: array
-      items:
-        $ref: '#/monster-damage'
-
-monster-abilities:
-  type: object
-  properties:
-    charisma:
-      description: "A monster's ability to charm or intimidate a player."
-      type: number
-    constitution:
-      description: How sturdy a monster is."
-      type: number
-    dexterity:
-      description: "The monster's ability for swift movement or stealth"
-      type: number
-    intelligence:
-      description: "The monster's ability to outsmart a player."
-      type: number
-    strength:
-      description: 'How hard a monster can hit a player.'
-      type: number
-    wisdom:
-      description: "A monster's ability to ascertain the player's plan."
-      type: number
-
-monster-proficiency:
-  type: object
-  properties:
-    value:
-      type: number
-    proficiency:
-      $ref: './combined.yml#/APIReference'
-
-monster-sense:
-  type: object
-  properties:
-    passive_perception:
-      description: The monster's passive perception (wisdom) score.
-      type: number
-    blindsight:
-      description: A monster with blindsight can perceive its surroundings without relying on sight, within a specific radius.
-      type: string
-    darkvision:
-      description: A monster with darkvision can see in the dark within a specific radius.
-      type: string
-    tremorsense:
-      description: A monster with tremorsense can detect and pinpoint the origin of vibrations within a specific radius, provided that the monster and the source of the vibrations are in contact with the same ground or substance.
-      type: string
-    truesight:
-      description: A monster with truesight can, out to a specific range, see in normal and magical darkness, see invisible creatures and objects, automatically detect visual illusions and succeed on saving throws against them, and perceive the original form of a shapechanger or a creature that is transformed by magic. Furthermore, the monster can see into the Ethereal Plane within the same range.
-      type: string
-
-monster-usage:
-  type: object
-  properties:
-    type:
-      type: string
-      enum:
-        - at will
-        - per day
-        - recharge after rest
-        - recharge on roll
-    rest_types:
-      type: array
-      items:
-        type: string
-    times:
-      type: number
-
-monster-spell:
-  type: object
-  properties:
-    name:
-      type: string
-    level:
-      type: number
-    url:
-      type: string
-    usage:
-      $ref: '#/monster-usage'
-
-monster-spellcasting:
-  type: object
-  properties:
-    ability:
-      $ref: './combined.yml#/APIReference'
-    dc:
-      type: number
-    modifier:
-      type: number
-    components_required:
-      type: array
-      items:
-        type: string
-    school:
-      type: string
-    slots:
-      type: object
-      additionalProperties:
-        type: number
-    spells:
-      type: array
-      items:
-        $ref: '#/monster-spell'
-
-monster-special-ability:
-  type: object
-  properties:
-    name:
-      type: string
-    desc:
-      type: string
-    attack_bonus:
-      type: number
-    damage:
-      type: array
-      items:
-        $ref: '#/monster-damage'
-    dc:
-      $ref: './combined.yml#/DC'
-    spellcasting:
-      $ref: '#/monster-spellcasting'
-    usage:
-      $ref: '#/monster-usage'
-
 monster-model:
   description: |
     `Monster`
   allOf:
     - $ref: './combined.yml#/APIReference'
     - $ref: './combined.yml#/ResourceDescription'
-    - $ref: '#/monster-abilities'
+    - $ref: './combined.yml#/MonsterAbility'
     - type: object
       properties:
         image:
@@ -288,7 +45,7 @@ monster-model:
           description: 'The difficulty for a player to successfully deal damage to a monster.'
           type: array
           items:
-            $ref: '#/monster-armor-class'
+            $ref: './combined.yml#/MonsterArmorClass'
         hit_points:
           description: 'The hit points of a monster determine how much damage it is able to take before it can be defeated.'
           type: number
@@ -302,12 +59,12 @@ monster-model:
           description: 'A list of actions that are available to the monster to take during combat.'
           type: array
           items:
-            $ref: '#/monster-action'
+            $ref: './combined.yml#/MonsterAction'
         legendary_actions:
           description: 'A list of legendary actions that are available to the monster to take during combat.'
           type: array
           items:
-            $ref: '#/monster-action'
+            $ref: './combined.yml#/MonsterAction'
         challenge_rating:
           description: "A monster's challenge rating is a guideline number that says when a monster becomes an appropriate challenge against the party's average level. For example. A group of 4 players with an average level of 4 would have an appropriate combat challenge against a monster with a challenge rating of 4 but a monster with a challenge rating of 8 against the same group of players would pose a significant threat."
           type: number
@@ -345,21 +102,21 @@ monster-model:
           description: 'A list of proficiencies of a monster.'
           type: array
           items:
-            $ref: '#/monster-proficiency'
+            $ref: './combined.yml#/MonsterProficiency'
         reactions:
           description: 'A list of reactions that is available to the monster to take during combat.'
           type: array
           items:
-            $ref: '#/monster-action'
+            $ref: './combined.yml#/MonsterAction'
         senses:
           description: 'Monsters typically have a passive perception but they might also have other senses to detect players.'
           allOf:
-            - $ref: '#/monster-sense'
+            - $ref: './combined.yml#/MonsterSense'
         special_abilities:
           description: "A list of the monster's special abilities."
           type: array
           items:
-            $ref: '#/monster-special-ability'
+            $ref: './combined.yml#/MonsterSpecialAbility'
         speed:
           description: 'Speed for a monster determines how fast it can move per turn.'
           type: object


### PR DESCRIPTION
## What does this do?

Move swagger schema model definitions for monster related things to their own file. Import those definitions in the combined file. Change all references to point to the combined file.

## How was it tested?

localhost and compared generated openapi specs with `npm run bundle-swagger`. The new spec does not contain the offending lines like `#/paths/~1api~1monsters~1%7Bindex%7D/get/responses/200/content/application~1json/schema/allOf/3/properties/actions/items/properties/damage/items'` anymore.

## Is there a Github issue this is resolving?

should address https://github.com/5e-bits/5e-srd-api/issues/352

## Was any impacted documentation updated to reflect this change?

this updates documentation

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
