### PR TITLE
fix(gql): add alignment field to monster type

### DIFF
--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -674,6 +674,7 @@ type MonsterArmorClass {
 type Monster {
   index: String!
   name: String!
+  alignment: String!
   armor_class: [MonsterArmorClass]
   desc: String
   actions: [MonsterAction!]


### PR DESCRIPTION
## What does this do?
expose `alignment` field on the `Monster` type

## How was it tested?
localhost
<img width="600" alt="Screenshot 2023-07-21 at 3 03 45 PM" src="https://github.com/5e-bits/5e-srd-api/assets/1425775/cf735104-97aa-46f6-a4c5-63dcbd33b9ff">

## Is there a Github issue this is resolving?
https://github.com/5e-bits/5e-srd-api/issues/358

## Was any impacted documentation updated to reflect this change?
no, docs were already correct

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
