### PR TITLE
chore: Setup app.json for review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,7 +32,7 @@
       "quantity": 1
     }
   },
-  "addons": ["bugsnag", "heroku-redis"],
+  "addons": ["bugsnag:tauron", "heroku-redis:mini"],
   "buildpacks": [
     {
       "url": "heroku/nodejs"


### PR DESCRIPTION
## What does this do?
Sets up `app.json` for Heroku to know what is needed to stand up review apps.

## How was it tested?
Doing it live. The config was pulled from Heroku.

## Is there a Github issue this is resolving?
Nope.

## Was any impacted documentation updated to reflect this change?
None.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
