### PR TITLE
feat: add proficiency_bonus field to Monsters

### DIFF
--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -679,6 +679,7 @@ type Monster {
   desc: String
   actions: [MonsterAction!]
   challenge_rating: Float!
+  proficiency_bonus: Int!
   charisma: Int!
   condition_immunities: [Condition!]!
   constitution: Int!

--- a/src/swagger/paths/monsters.yml
+++ b/src/swagger/paths/monsters.yml
@@ -102,6 +102,7 @@ monster-index:
                 - type: natural
                   value: 17
               challenge_rating: 10
+              proficiency_bonus: 4
               charisma: 18
               condition_immunities: []
               constitution: 15

--- a/src/swagger/schemas/monsters.yml
+++ b/src/swagger/schemas/monsters.yml
@@ -70,6 +70,11 @@ monster-model:
           type: number
           minimum: 0
           maximum: 21
+        proficiency_bonus:
+          description: "A monster's proficiency bonus is the number added to ability checks, saving throws and attack rolls in which the monster is proficient, and is linked to the monster's challenge rating. This bonus has already been included in the monster's stats where applicable."
+          type: number
+          minimum: 2
+          maximum: 9
         condition_immunities:
           description: 'A list of conditions that a monster is immune to.'
           type: array


### PR DESCRIPTION
## What does this do?
Updates the swagger and graphql schemas for the new `proficiency_bonus` field on Monster documents.

## How was it tested?
Built the image and tested locally

## Is there a Github issue this is resolving?
Resolves 5e-database#550, alongside [database changes](https://github.com/5e-bits/5e-database/pull/551).

## Was any impacted documentation updated to reflect this change?
Docs generated from swagger will be updated.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
