### PR TITLE
feat(docs): Link to new docs

### DIFF
--- a/src/views/partials/navbar.ejs
+++ b/src/views/partials/navbar.ejs
@@ -15,7 +15,7 @@
     <div class="collapse navbar-collapse navbar-right">
       <ul class="nav navbar-nav">
         <li class="active"><a href="/">Home</a></li>
-        <li><a href="/docs/">Documentation</a></li>
+        <li><a href="https://5e-bits.github.io/docs">Documentation</a></li>
         <li><a href="https://discord.gg/TQuYTv7">Chat</a></li>
         <li><a href="https://github.com/bagelbits/5e-srd-api">Contribute</a></li>
       </ul>


### PR DESCRIPTION
## What does this do?

Links to our new docs site.

## How was it tested?

Similar to our other links and I tested the URL

## Is there a Github issue this is resolving?

Not really

## Was any impacted documentation updated to reflect this change?

Buddy you have no idea

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
