### PR TITLE
feat: added error handler middleware and rate limiting improvements

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+
+const errorHandler = (err: any, req: Request, res: Response, next: NextFunction): void => {
+  console.error(err.stack);
+
+  res.status(err.status || 404).json({
+    error: err,
+    message: err.message,
+    details: err.errors,
+  });
+};
+
+export default errorHandler;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import apiRoutes from './routes/api.js';
 import bugsnagMiddleware from './middleware/bugsnag.js';
+import errorHandlerMiddleware from './middleware/errorHandler.js';
 import cors from 'cors';
 import bodyParser from 'body-parser';
 import { createApolloMiddleware } from './middleware/apolloServer.js';
@@ -18,7 +19,8 @@ const __dirname = path.dirname(__filename);
 
 const limiter = rateLimit({
   windowMs: 1000, // 1 second
-  max: 10000, // limit each IP to 10000 requests per windowMs
+  max: 1000, // limit each IP to 10000 requests per windowMs
+  message: 'Rate limit of 1000 requests per second exceeded, try again in a second',
 });
 
 export default async () => {
@@ -58,22 +60,12 @@ export default async () => {
   app.get('/docs', docsController);
   app.use('/api', apiRoutes);
 
-  app.use(function (req: express.Request, res: express.Response) {
-    res.status(404);
-
-    // TODO: Add a fun 404 page
-    // // respond with html page
-    // if (req.accepts('html')) {
-    //   res.render('404', { url: req.url });
-    //   return;
-    // }
-
-    // default respond with json
-    return res.send({ error: 'Not found' });
-  });
-
   if (bugsnagMiddleware?.errorHandler) {
     app.use(bugsnagMiddleware.errorHandler);
+  }
+
+  if (errorHandlerMiddleware) {
+    app.use(errorHandlerMiddleware);
   }
   return app;
 };


### PR DESCRIPTION
## What does this do?
- Adds an error handler middleware to the express server so errors are neatly caught and responded to in JSON format
- Bumps the rate limit to something a little more reasonable like 1000req/sec per IP instead of the 10,000 it was before 

## How was it tested?
Ran npm run test:unit to verify all the handlers still worked

## Is there a Github issue this is resolving?
Nope

## Was any impacted documentation updated to reflect this change?
Nope

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
