### PR TITLE
fix: reduce rate limit to 50 requests per second per IP

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -19,8 +19,8 @@ const __dirname = path.dirname(__filename);
 
 const limiter = rateLimit({
   windowMs: 1000, // 1 second
-  max: 1000, // limit each IP to 1000 requests per windowMs
-  message: 'Rate limit of 1000 requests per second exceeded, try again in a second',
+  max: 50, // limit each IP to 50 requests per windowMs
+  message: 'Rate limit of 50 requests per second exceeded, try again in a second',
 });
 
 export default async () => {


### PR DESCRIPTION
## What does this do?
Reduce rate limit to 50 requests per second per IP address.

## How was it tested?
Unit tests were ran

## Is there a Github issue this is resolving?
Nope

## Was any impacted documentation updated to reflect this change?
Not yet. We should probably add a tutorial showing how to handle rate limiting in our documentation.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
