### PR TITLE
feat: upgrade mongoose to 8.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "graphql-compose": "^9.0.11",
         "graphql-compose-mongoose": "^10.0.0",
         "graphql-depth-limit": "^1.1.0",
-        "mongoose": "^8.5.4",
+        "mongoose": "^8.8.2",
         "morgan": "^1.10.0",
         "node-fetch": "^3.1.1",
         "redis": "^4.7.0",
@@ -3069,9 +3069,10 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.7.tgz",
-      "integrity": "sha512-dCHW/oEX0KJ4NjDULBo3JiOaK5+6axtpBbS+ao2ZInoAL9/YRQLhXzSNAFz7hP4nzLkIqsfYAK/PDE3+XHny0Q==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+      "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -4988,12 +4989,14 @@
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
       "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -5920,9 +5923,10 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.8.0.tgz",
-      "integrity": "sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.0.tgz",
+      "integrity": "sha512-ROchNosXMJD2cbQGm84KoP7vOGPO6/bOAW0veMMbzhXLqoZptcaYRVLitwvuhwhjjpU1qP4YZRWLhgETdgqUQw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
       }
@@ -11329,7 +11333,8 @@
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -11600,9 +11605,10 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.7.0.tgz",
-      "integrity": "sha512-TMKyHdtMcO0fYBNORiYdmM25ijsHs+Njs963r4Tro4OQZzqYigAzYQouwWRg4OIaiLRUEGUh/1UAcH5lxdSLIA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.10.0.tgz",
+      "integrity": "sha512-gP9vduuYWb9ZkDM546M+MP2qKVk5ZG2wPF63OvSRuUbqCR+11ZCAE1mOfllhlAG0wcoJY5yDL/rV3OmYEwXIzg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.5",
         "bson": "^6.7.0",
@@ -11648,6 +11654,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
       "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^13.0.0"
@@ -11657,6 +11664,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
       "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.0"
       },
@@ -11668,6 +11676,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       }
@@ -11676,6 +11685,7 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
       "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "^4.1.1",
         "webidl-conversions": "^7.0.0"
@@ -11685,13 +11695,14 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.5.4.tgz",
-      "integrity": "sha512-nG3eehhWf9l1q80WuHvp5DV+4xDNFpDWLE5ZgcFD5tslUV2USJ56ogun8gaZ62MKAocJnoStjAdno08b8U57hg==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.8.2.tgz",
+      "integrity": "sha512-jCTSqDANfRzk909v4YoZQi7jlGRB2MTvgG+spVBc/BA4tOs1oWJr//V6yYujqNq9UybpOtsSfBqxI0dSOEFJHQ==",
+      "license": "MIT",
       "dependencies": {
         "bson": "^6.7.0",
         "kareem": "2.6.3",
-        "mongodb": "6.7.0",
+        "mongodb": "~6.10.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -17612,6 +17623,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "graphql-compose": "^9.0.11",
     "graphql-compose-mongoose": "^10.0.0",
     "graphql-depth-limit": "^1.1.0",
-    "mongoose": "^8.5.4",
+    "mongoose": "^8.8.2",
     "morgan": "^1.10.0",
     "node-fetch": "^3.1.1",
     "redis": "^4.7.0",

--- a/src/graphql/resolvers/common.ts
+++ b/src/graphql/resolvers/common.ts
@@ -1,7 +1,7 @@
 import AbilityScoreModel from '../../models/abilityScore/index.js';
-import EquipmentCategoryModel from '../../models/equipmentCategory/index.js';
+import { AreaOfEffect, Choice, DifficultyClass } from '../../models/common/types';
 import { Equipment } from '../../models/equipment/types';
-import { DifficultyClass, AreaOfEffect, Choice } from '../../models/common/types';
+import EquipmentCategoryModel from '../../models/equipmentCategory/index.js';
 import SpellModel from '../../models/spell/index.js';
 
 export const equipmentBaseFieldResolvers = {
@@ -259,7 +259,7 @@ export type ResolvedDC = {
 };
 export const resolveDc = async (dc: DifficultyClass) => {
   const resolvedDc: ResolvedDC = {
-    type: (await AbilityScoreModel.findOne({ index: dc.dc_type.index }).lean()) || '',
+    type: (await AbilityScoreModel.findOne({ index: dc.dc_type.index }).lean())?.name || '',
     success: dc.success_type.toUpperCase(),
   };
 

--- a/src/graphql/resolvers/featureResolver.ts
+++ b/src/graphql/resolvers/featureResolver.ts
@@ -82,15 +82,15 @@ const Feature = {
       const prerequisiteToReturn = { ...prerequisite };
 
       if ('feature' in prerequisite && 'feature' in prerequisiteToReturn) {
-        prerequisiteToReturn.feature =
-          (await FeatureModel.findOne({
-            url: prerequisite.feature,
-          }).lean()) || '';
+        const foundFeature = await FeatureModel.findOne({
+          url: prerequisite.feature,
+        }).lean();
+        prerequisiteToReturn.feature = foundFeature?.url || prerequisite.feature;
       }
 
       if ('spell' in prerequisite && 'spell' in prerequisiteToReturn) {
         prerequisiteToReturn.spell =
-          (await SpellModel.findOne({ url: prerequisite.spell }).lean()) || '';
+          (await SpellModel.findOne({ url: prerequisite.spell }).lean())?.url || prerequisite.spell;
       }
 
       return prerequisiteToReturn;


### PR DESCRIPTION
## What does this do?
-  upgrade mongoose to 8.8.2
- fix two resulting type errors

## How was it tested?
- ran tests locally
- built docker image locally

## Is there a Github issue this is resolving?
- covers the dependabot PR here: https://github.com/5e-bits/5e-srd-api/pull/563

## Was any impacted documentation updated to reflect this change?
- shouldn't need any new docs

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
