### PR TITLE
WIP - fix: update spec generation to align with reality

### DIFF
--- a/src/swagger/schemas/monsters.yml
+++ b/src/swagger/schemas/monsters.yml
@@ -26,21 +26,9 @@ monster-model:
         subtype:
           description: The sub-category of a monster used for classification of monsters."
           type: string
-        alignments:
+        alignment:
           description: "A creature's general moral and personal attitudes."
           type: string
-          enum:
-            - chaotic neutral
-            - chaotic evil
-            - chaotic good
-            - lawful neutral
-            - lawful evil
-            - lawful good
-            - neutral
-            - neutral evil
-            - neutral good
-            - any alignment
-            - unaligned
         armor_class:
           description: 'The difficulty for a player to successfully deal damage to a monster.'
           type: array


### PR DESCRIPTION
## What does this do?
- Various changes to swagger docs to align with public documentation and actual endpoint responses.

## How was it tested?
- localhost 
- a lot of playing around with schema generators

## Is there a Github issue this is resolving?
#619 
#358 

## Was any impacted documentation updated to reflect this change?
This is docs, sort of

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
