### PR TITLE
fix: correct class spell list example

### DIFF
--- a/src/swagger/api-spec/openapi.json
+++ b/src/swagger/api-spec/openapi.json
@@ -880,12 +880,14 @@
                     {
                       "index": "power-word-kill",
                       "name": "Power Word Kill",
-                      "url": "/api/spells/power-word-kill"
+                      "url": "/api/spells/power-word-kill",
+                      "level": 9
                     },
                     {
                       "index": "true-polymorph",
                       "name": "True Polymorph",
-                      "url": "/api/spells/true-polymorph"
+                      "url": "/api/spells/true-polymorph",
+                      "level": 9
                     }
                   ]
                 }

--- a/src/swagger/api-spec/openapi.yml
+++ b/src/swagger/api-spec/openapi.yml
@@ -560,9 +560,11 @@ paths:
                   - index: power-word-kill
                     name: Power Word Kill
                     url: /api/spells/power-word-kill
+                    level: 9
                   - index: true-polymorph
                     name: True Polymorph
                     url: /api/spells/true-polymorph
+                    level: 9
   '/api/classes/{index}/spellcasting':
     get:
       summary: Get spellcasting info for a class.

--- a/src/swagger/paths/classes.yml
+++ b/src/swagger/paths/classes.yml
@@ -208,9 +208,11 @@ class-spells-path:
                 - index: power-word-kill
                   name: Power Word Kill
                   url: '/api/spells/power-word-kill'
+                  level: 9
                 - index: true-polymorph
                   name: True Polymorph
                   url: '/api/spells/true-polymorph'
+                  level: 9
 # /api/classes/{index}/spellcasting
 class-spellcasting-path:
   get:


### PR DESCRIPTION
This is the only place where we do return the level along with the spell apireference.

