### PR TITLE
fix: include code.js in tsconfig

### DIFF
--- a/src/js/code.js
+++ b/src/js/code.js
@@ -1,4 +1,5 @@
-function update(call) {// eslint-disable-line
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function update(call) {
   $('#interactive').val(call);
   interactive_call();
 }

--- a/tools/copyAssets.ts
+++ b/tools/copyAssets.ts
@@ -6,4 +6,4 @@ shell.mkdir('-p', 'dist');
 shell.cp('-R', 'src/css', 'dist/src');
 shell.cp('-R', 'src/public', 'dist/src');
 shell.cp('-R', 'src/views', 'dist/src');
-shell.cp('-R', 'src/swagger/dist', 'dist/src/swagger');
+shell.cp('-R', 'src/swagger/api-spec', 'dist/src/swagger');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -91,6 +91,7 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": [
+    "src/js/**/*.js",
     "src/**/*.ts",
     "tools/**/*.ts",
     "jest.config.integration.ts",


### PR DESCRIPTION
## What does this do?
- include the /src/js directory so it gets picked up at buildtime
- use suggested inline ignore comment
- also update copyAssets to copy openapi spec to correct directory

## How was it tested?
localhost
![landing](https://github.com/user-attachments/assets/cee26dc0-05db-4f65-a168-df566e12310a)

- also built the docker image and ran it locally to double check

## Is there a Github issue this is resolving?
- I broke this last week making some eslint / ts configuration changes
#622 

## Was any impacted documentation updated to reflect this change?
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
