### PR TITLE
fix: Aligning background.starting_equipment with reality

### DIFF
--- a/src/swagger/schemas/backgrounds.yml
+++ b/src/swagger/schemas/backgrounds.yml
@@ -14,7 +14,12 @@ background-model:
           description: 'Starting equipment for all new characters of this background.'
           type: array
           items:
-            $ref: './combined.yml#/APIReference'
+            type: object
+            properties:
+              quantity:
+                type: number
+              equipment:
+                $ref: './combined.yml#/APIReference'
         starting_equipment_options:
           $ref: './combined.yml#/Choice'
         language_options:


### PR DESCRIPTION
## What does this do?
Think I found an inconsistency. This solution aligns with the use of starting_equipment in classes.

## How was it tested?
I'm not that familiar with the project. I hope someone else can validate that it works.

## Is there a Github issue this is resolving?
I found this 5 min ago, and thought I should simply push what I think solve the problem. Hopefully I'm not stepping on anyone toes.

## Was any impacted documentation updated to reflect this change?
Don't think this is necessary?

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
