### PR TITLE
fix(swagger): Improving the type for background.personality_traits

### DIFF
--- a/src/swagger/schemas/backgrounds.yml
+++ b/src/swagger/schemas/backgrounds.yml
@@ -30,9 +30,7 @@ background-model:
               items:
                 type: string
         personality_traits:
-          description: Choice of personality traits for this background.
-          type: object
-
+          $ref: './combined.yml#/Choice'
         ideals:
           $ref: './combined.yml#/Choice'
         bonds:


### PR DESCRIPTION
## What does this do?
I use the openapi.json that's created from this, and this change should align better with the structure of background.personality_traits

## How was it tested?
As with the last PR, I'm not familiar with the testing regime of this project. I hope this commit is still ok.

## Is there a Github issue this is resolving?
None yet.

## Was any impacted documentation updated to reflect this change?
None needed I think?

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
