### PR TITLE
fix(swagger): Aligning background.starting_equipment_options with reality

### DIFF
--- a/src/swagger/schemas/backgrounds.yml
+++ b/src/swagger/schemas/backgrounds.yml
@@ -16,7 +16,10 @@ background-model:
           items:
             $ref: './combined.yml#/APIReference'
         starting_equipment_options:
-          $ref: './combined.yml#/Choice'
+          description: List of choices of starting equipment.
+          type: array
+          items:
+            $ref: './combined.yml#/Choice'
         language_options:
           $ref: './combined.yml#/Choice'
         feature:


### PR DESCRIPTION
Found another inconsistency

## What does this do?
Changing background.starting_equipment_options from a singular Choice to multiple Choice (which is what the actual data

## How was it tested?
No tests AFAIK

## Is there a Github issue this is resolving?
No

## Was any impacted documentation updated to reflect this change?
No documentation impacted I think?

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/300)
