### PR TITLE
fix: Aligning option_set.resource_link with reality

### DIFF
--- a/src/swagger/schemas/common.yml
+++ b/src/swagger/schemas/common.yml
@@ -193,7 +193,7 @@ option-set-model:
         option_set_type:
           description: 'Type of option set; determines other attributes.'
           type: string
-        resource_list:
+        resource_list_url:
           description: 'A reference (by URL) to a collection in the database.'
           type: string
 choice-model:


### PR DESCRIPTION
Another inconsistency with the API

## What does this do?
Fixing property name "resource_list" --> "resource_list_url"

## How was it tested?
Not tested

## Is there a Github issue this is resolving?
No

## Was any impacted documentation updated to reflect this change?
Not that I know of

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/333)
