### PR TITLE
fix(copyAssets): Remove copyAssets need

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:ts": "tsc",
     "build": "npm-run-all --sequential clean bundle-swagger build:ts copy-assets",
     "clean": "rimraf dist/*",
-    "copy-assets": "node --no-warnings --loader ts-node/esm tools/copyAssets.ts",
+    "copy-assets": "mkdir -p dist && cp -R src/css dist/src && cp -R src/public dist/src && cp -R src/views dist/src && cp -R src/swagger/api-spec dist/src/swagger",
     "start": "npm run build && node dist/src/start.js",
     "dev": "nodemon npm run start",
     "lint": "eslint . --config eslint.config.js",

--- a/tools/copyAssets.ts
+++ b/tools/copyAssets.ts
@@ -1,9 +1,0 @@
-import shell from 'shelljs';
-
-shell.mkdir('-p', 'dist');
-
-// Copy all the view templates
-shell.cp('-R', 'src/css', 'dist/src');
-shell.cp('-R', 'src/public', 'dist/src');
-shell.cp('-R', 'src/views', 'dist/src');
-shell.cp('-R', 'src/swagger/api-spec', 'dist/src/swagger');


### PR DESCRIPTION
## What does this do?

Migrates the `copyAssets.ts` to an inline command in `package.json`

## How was it tested?

`docker-compose up --build`

## Is there a Github issue this is resolving?

No.

## Was any impacted documentation updated to reflect this change?

No.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
