### PR TITLE
feat(api): Add updated_at to all entities

### DIFF
--- a/src/models/2014/abilityScore/index.ts
+++ b/src/models/2014/abilityScore/index.ts
@@ -10,6 +10,7 @@ const AbilityScoreSchema = new Schema<AbilityScore>({
   name: { type: String, index: true },
   skills: [APIReferenceSchema],
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('AbilityScore', AbilityScoreSchema, '2014-ability-scores');

--- a/src/models/2014/abilityScore/types.d.ts
+++ b/src/models/2014/abilityScore/types.d.ts
@@ -9,4 +9,5 @@ export type AbilityScore = {
   name: string;
   skills: APIReference[] | [];
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/alignment/index.ts
+++ b/src/models/2014/alignment/index.ts
@@ -8,6 +8,7 @@ const AlignmentSchema = new Schema<Alignment>({
   index: { type: String, index: true },
   name: { type: String, index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Alignment', AlignmentSchema, '2014-alignments');

--- a/src/models/2014/alignment/types.d.ts
+++ b/src/models/2014/alignment/types.d.ts
@@ -7,4 +7,5 @@ export type Alignment = {
   index: string;
   name: string;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/background/index.ts
+++ b/src/models/2014/background/index.ts
@@ -28,6 +28,7 @@ const BackgroundSchema = new Schema<Background>({
   ideals: ChoiceSchema,
   bonds: ChoiceSchema,
   flaws: ChoiceSchema,
+  updated_at: { type: String, index: true },
 });
 
 export default model('Background', BackgroundSchema, '2014-backgrounds');

--- a/src/models/2014/background/types.d.ts
+++ b/src/models/2014/background/types.d.ts
@@ -27,4 +27,5 @@ export type Background = {
   ideals: Choice;
   bonds: Choice;
   flaws: Choice;
+  updated_at: string;
 };

--- a/src/models/2014/class/index.ts
+++ b/src/models/2014/class/index.ts
@@ -58,6 +58,7 @@ const ClassSchema = new Schema<Class>({
   starting_equipment_options: [ChoiceSchema],
   subclasses: [APIReferenceSchema],
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Class', ClassSchema, '2014-classes');

--- a/src/models/2014/class/types.d.ts
+++ b/src/models/2014/class/types.d.ts
@@ -55,4 +55,5 @@ export type Class = {
   starting_equipment_options: Choice[];
   subclasses: APIReference[];
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/condition/index.ts
+++ b/src/models/2014/condition/index.ts
@@ -7,6 +7,7 @@ const ConditionSchema = new Schema<Condition>({
   index: { type: String, index: true },
   name: { type: String, index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Condition', ConditionSchema, '2014-conditions');

--- a/src/models/2014/condition/types.d.ts
+++ b/src/models/2014/condition/types.d.ts
@@ -6,4 +6,5 @@ export type Condition = {
   index: string;
   name: string;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/damageType/index.ts
+++ b/src/models/2014/damageType/index.ts
@@ -7,6 +7,7 @@ const DamageTypeSchema = new Schema<DamageType>({
   index: { type: String, index: true },
   name: { type: String, index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('DamageType', DamageTypeSchema, '2014-damage-types');

--- a/src/models/2014/damageType/types.d.ts
+++ b/src/models/2014/damageType/types.d.ts
@@ -6,4 +6,5 @@ export type DamageType = {
   index: string;
   name: string;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/equipment/index.ts
+++ b/src/models/2014/equipment/index.ts
@@ -90,6 +90,7 @@ const EquipmentSchema = new Schema<Equipment>({
   weapon_category: { type: String, index: true },
   weapon_range: { type: String, index: true },
   weight: { type: Number, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Equipment', EquipmentSchema, '2014-equipment');

--- a/src/models/2014/equipment/types.d.ts
+++ b/src/models/2014/equipment/types.d.ts
@@ -79,4 +79,5 @@ export type Equipment = {
   weapon_category?: string;
   weapon_range?: string;
   weight?: number;
+  updated_at: string;
 };

--- a/src/models/2014/equipmentCategory/index.ts
+++ b/src/models/2014/equipmentCategory/index.ts
@@ -8,6 +8,7 @@ const EquipmentCategorySchema = new Schema<EquipmentCategory>({
   index: { type: String, index: true },
   name: { type: String, index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('EquipmentCategory', EquipmentCategorySchema, '2014-equipment-categories');

--- a/src/models/2014/equipmentCategory/types.d.ts
+++ b/src/models/2014/equipmentCategory/types.d.ts
@@ -7,4 +7,5 @@ export type EquipmentCategory = {
   index: string;
   name: string;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/feat/index.ts
+++ b/src/models/2014/feat/index.ts
@@ -15,6 +15,7 @@ const FeatSchema = new Schema<Feat>({
   prerequisites: [PrerequisiteSchema],
   desc: { type: [String], index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Feat', FeatSchema, '2014-feats');

--- a/src/models/2014/feat/types.d.ts
+++ b/src/models/2014/feat/types.d.ts
@@ -14,4 +14,5 @@ export type Feat = {
   prerequisites: Prerequisite[];
   desc: string[];
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/feature/index.ts
+++ b/src/models/2014/feature/index.ts
@@ -48,6 +48,7 @@ const FeatureSchema = new Schema<Feature>({
   subclass: APIReferenceSchema,
   feature_specific: FeatureSpecificSchema,
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Feature', FeatureSchema, '2014-features');

--- a/src/models/2014/feature/types.d.ts
+++ b/src/models/2014/feature/types.d.ts
@@ -41,4 +41,5 @@ export type Feature = {
   subclass?: APIReference;
   feature_specific?: FeatureSpecific;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/language/index.ts
+++ b/src/models/2014/language/index.ts
@@ -10,6 +10,7 @@ const LanguageSchema = new Schema<Language>({
   type: { type: String, index: true },
   typical_speakers: { type: [String], index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Language', LanguageSchema, '2014-languages');

--- a/src/models/2014/language/types.d.ts
+++ b/src/models/2014/language/types.d.ts
@@ -9,4 +9,5 @@ export type Language = {
   type: string;
   typical_speakers: string[];
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/level/index.ts
+++ b/src/models/2014/level/index.ts
@@ -101,6 +101,7 @@ const LevelSchema = new Schema<Level>({
   subclass: APIReferenceSchema,
   subclass_specific: SubclassSpecificSchema,
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Level', LevelSchema, '2014-levels');

--- a/src/models/2014/level/types.d.ts
+++ b/src/models/2014/level/types.d.ts
@@ -89,4 +89,5 @@ export type Level = {
   subclass?: APIReference;
   subclass_specific?: SubclassSpecific;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/magicItem/index.ts
+++ b/src/models/2014/magicItem/index.ts
@@ -18,6 +18,7 @@ const MagicItemSchema = new Schema<MagicItem>({
   url: { type: String, index: true },
   variants: [APIReferenceSchema],
   variant: Boolean,
+  updated_at: { type: String, index: true },
 });
 
 export default model('MagicItem', MagicItemSchema, '2014-magic-items');

--- a/src/models/2014/magicItem/types.d.ts
+++ b/src/models/2014/magicItem/types.d.ts
@@ -17,4 +17,5 @@ export type MagicItem = {
   url: string;
   variants: APIReference[];
   variant: boolean;
+  updated_at: string;
 };

--- a/src/models/2014/magicSchool/index.ts
+++ b/src/models/2014/magicSchool/index.ts
@@ -7,6 +7,7 @@ const MagicSchoolSchema = new Schema<MagicSchool>({
   index: { type: String, index: true },
   name: { type: String, index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('MagicSchool', MagicSchoolSchema, '2014-magic-schools');

--- a/src/models/2014/magicSchool/types.d.ts
+++ b/src/models/2014/magicSchool/types.d.ts
@@ -6,4 +6,5 @@ export type MagicSchool = {
   index: string;
   name: string;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/monster/index.ts
+++ b/src/models/2014/monster/index.ts
@@ -197,6 +197,7 @@ const Monster = new Schema<Monster>({
   url: { type: String, index: true },
   wisdom: { type: Number, index: true },
   xp: { type: Number, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Monster', Monster, '2014-monsters');

--- a/src/models/2014/monster/types.d.ts
+++ b/src/models/2014/monster/types.d.ts
@@ -189,4 +189,5 @@ export type Monster = {
   url: string;
   wisdom: number;
   xp: number;
+  updated_at: string;
 };

--- a/src/models/2014/proficiency/index.ts
+++ b/src/models/2014/proficiency/index.ts
@@ -19,6 +19,7 @@ const ProficiencySchema = new Schema<Proficiency>({
   reference: ReferenceSchema,
   type: { type: String, index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Proficiency', ProficiencySchema, '2014-proficiencies');

--- a/src/models/2014/proficiency/types.d.ts
+++ b/src/models/2014/proficiency/types.d.ts
@@ -18,4 +18,5 @@ export type Proficiency = {
   reference: Reference;
   type: string;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/race/index.ts
+++ b/src/models/2014/race/index.ts
@@ -27,6 +27,7 @@ const RaceSchema = new Schema<Race>({
   subraces: [APIReferenceSchema],
   traits: [APIReferenceSchema],
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Race', RaceSchema, '2014-races');

--- a/src/models/2014/race/types.d.ts
+++ b/src/models/2014/race/types.d.ts
@@ -26,4 +26,5 @@ export type Race = {
   subraces?: APIReference[];
   traits?: APIReference[];
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/rule/index.ts
+++ b/src/models/2014/rule/index.ts
@@ -9,6 +9,7 @@ const RuleSchema = new Schema<Rule>({
   name: { type: String, index: true },
   subsections: [APIReferenceSchema],
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Rule', RuleSchema, '2014-rules');

--- a/src/models/2014/rule/types.d.ts
+++ b/src/models/2014/rule/types.d.ts
@@ -8,4 +8,5 @@ export type Rule = {
   name: string;
   subsections: APIReference[];
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/ruleSection/index.ts
+++ b/src/models/2014/ruleSection/index.ts
@@ -7,6 +7,7 @@ const RuleSectionSchema = new Schema<RuleSection>({
   index: { type: String, index: true },
   name: { type: String, index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('RuleSection', RuleSectionSchema, '2014-rule-sections');

--- a/src/models/2014/ruleSection/types.d.ts
+++ b/src/models/2014/ruleSection/types.d.ts
@@ -6,4 +6,5 @@ export type RuleSection = {
   index: string;
   name: string;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/skill/index.ts
+++ b/src/models/2014/skill/index.ts
@@ -9,6 +9,7 @@ const SkillSchema = new Schema<Skill>({
   index: { type: String, index: true },
   name: { type: String, index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Skill', SkillSchema, '2014-skills');

--- a/src/models/2014/skill/types.d.ts
+++ b/src/models/2014/skill/types.d.ts
@@ -8,4 +8,5 @@ export type Skill = {
   index: string;
   name: string;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/spell/index.ts
+++ b/src/models/2014/spell/index.ts
@@ -42,6 +42,7 @@ const Spell = new Schema({
   school: APIReferenceSchema,
   subclasses: [APIReferenceSchema],
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Spell', Spell, '2014-spells');

--- a/src/models/2014/spell/types.d.ts
+++ b/src/models/2014/spell/types.d.ts
@@ -38,4 +38,5 @@ export interface Spell {
   school: APIReference;
   subclasses?: APIReference[];
   url: string;
+  updated_at: string;
 }

--- a/src/models/2014/subclass/index.ts
+++ b/src/models/2014/subclass/index.ts
@@ -26,6 +26,7 @@ const SubclassSchema = new Schema<Subclass>({
   subclass_flavor: { type: String, index: true },
   subclass_levels: { type: String, index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Subclass', SubclassSchema, '2014-subclasses');

--- a/src/models/2014/subclass/types.d.ts
+++ b/src/models/2014/subclass/types.d.ts
@@ -25,4 +25,5 @@ export type Subclass = {
   subclass_flavor: string;
   subclass_levels: string;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/subrace/index.ts
+++ b/src/models/2014/subrace/index.ts
@@ -19,6 +19,7 @@ const Subrace = new Schema<Subrace>({
   racial_traits: [APIReferenceSchema],
   starting_proficiencies: [APIReferenceSchema],
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Subrace', Subrace, '2014-subraces');

--- a/src/models/2014/subrace/types.d.ts
+++ b/src/models/2014/subrace/types.d.ts
@@ -18,4 +18,5 @@ export type Subrace = {
   racial_traits: APIReference[];
   starting_proficiencies?: APIReference[];
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/trait/index.ts
+++ b/src/models/2014/trait/index.ts
@@ -58,6 +58,7 @@ const TraitSchema = new Schema<Trait>({
   parent: APIReferenceSchema,
   trait_specific: TraitSpecificSchema,
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('Trait', TraitSchema, '2014-traits');

--- a/src/models/2014/trait/types.d.ts
+++ b/src/models/2014/trait/types.d.ts
@@ -51,4 +51,5 @@ export type Trait = {
   parent?: APIReference;
   trait_specific?: TraitSpecific;
   url: string;
+  updated_at: string;
 };

--- a/src/models/2014/weaponProperty/index.ts
+++ b/src/models/2014/weaponProperty/index.ts
@@ -7,6 +7,7 @@ const WeaponPropertySchema = new Schema<WeaponProperty>({
   index: { type: String, index: true },
   name: { type: String, index: true },
   url: { type: String, index: true },
+  updated_at: { type: String, index: true },
 });
 
 export default model('WeaponProperty', WeaponPropertySchema, '2014-weapon-properties');

--- a/src/models/2014/weaponProperty/types.d.ts
+++ b/src/models/2014/weaponProperty/types.d.ts
@@ -6,4 +6,5 @@ export type WeaponProperty = {
   index: string;
   name: string;
   url: string;
+  updated_at: string;
 };

--- a/src/swagger/schemas/2014/common.yml
+++ b/src/swagger/schemas/2014/common.yml
@@ -12,6 +12,9 @@ api-ref-model:
     url:
       description: 'URL of the referenced resource.'
       type: string
+    updated_at:
+      description: 'Date and time the resource was last updated.'
+      type: string
 api-ref-list-model:
   description: |
     `APIReferenceList`


### PR DESCRIPTION
## What does this do?

* Adds `updated_at` to every model
* Adds `updated_at` to every model type
* Adds `updated_at` to the base APIReference in swagger

## How was it tested?

CI

## Is there a Github issue this is resolving?

No. But an asked for feature.

## Was any impacted documentation updated to reflect this change?

[Yes](https://github.com/5e-bits/docs/pull/110)

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
