### PR TITLE
feat: :wastebasket: Redirect deprecated `/api` requests to `/api/2014`

### DIFF
--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -1,10 +1,10 @@
-import { Request, Response } from "express";
+import { Request, Response } from 'express';
 import Collection from '../models/2014/collection/index.js';
 
 export default async (req: Request, res: Response) => {
   const collections = await Collection.find({});
 
-  const colName = req.path.split("/")[1]
+  const colName = req.path.split('/')[1]
   const colRequested = collections.find(col => col.index === colName)
 
   if (colRequested === undefined && colName !== '') {
@@ -12,6 +12,6 @@ export default async (req: Request, res: Response) => {
     return;
   }
 
-  const redirectUrl = "/api/2014" + req.path
+  const redirectUrl = '/api/2014' + req.path
   res.redirect(301, redirectUrl)
 };

--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -1,17 +1,21 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import Collection from '../models/2014/collection/index.js';
 
-export default async (req: Request, res: Response) => {
-  const collections = await Collection.find({});
+export default async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const collections = await Collection.find({});
 
-  const colName = req.path.split('/')[1]
-  const colRequested = collections.find(col => col.index === colName)
+    const colName = req.path.split('/')[1]
+    const colRequested = collections.find(col => col.index === colName)
 
-  if (colRequested === undefined && colName !== '') {
-    res.sendStatus(404)
-    return;
+    if (colRequested === undefined && colName !== '') {
+      res.sendStatus(404)
+      return;
+    }
+
+    const redirectUrl = '/api/2014' + req.path
+    res.redirect(301, redirectUrl)
+  } catch (err) {
+    next(err);
   }
-
-  const redirectUrl = '/api/2014' + req.path
-  res.redirect(301, redirectUrl)
 };

--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -5,16 +5,20 @@ export default async (req: Request, res: Response, next: NextFunction) => {
   try {
     const collections = await Collection.find({});
 
-    const colName = req.path.split('/')[1]
-    const colRequested = collections.find(col => col.index === colName)
+    const colName = req.path.split('/')[1];
+    const colRequested = collections.find(col => col.index === colName);
 
     if (colRequested === undefined && colName !== '') {
-      res.sendStatus(404)
+      res.sendStatus(404);
       return;
     }
-
-    const redirectUrl = '/api/2014' + req.path
-    res.redirect(301, redirectUrl)
+    
+    const queryString = req.originalUrl.split('?')?.[1];
+    const redirectUrl = '/api/2014' + req.path;
+    const urlWithQuery = queryString === undefined
+      ? redirectUrl
+      : redirectUrl + '?' + queryString;
+    res.redirect(301, urlWithQuery);
   } catch (err) {
     next(err);
   }

--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -1,22 +1,17 @@
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response } from "express";
 import Collection from '../models/2014/collection/index.js';
 
-export const index = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const data = await Collection.find({})
-      .select({ index: 1, _id: 0 })
-      .sort({ index: 'asc' })
-      .exec();
+export default async (req: Request, res: Response) => {
+  const collections = await Collection.find({});
 
-    const apiIndex: Record<string, string> = { '2014': '/api/2014' };
-    data.forEach((item) => {
-      if (item.index === 'levels') return;
+  const colName = req.path.split("/")[1]
+  const colRequested = collections.find(col => col.index === colName)
 
-      apiIndex[item.index] = `/api/${item.index}`;
-    });
-
-    return res.status(200).json(apiIndex);
-  } catch (err) {
-    next(err);
+  if (colRequested === undefined && colName !== '') {
+    res.sendStatus(404)
+    return;
   }
+
+  const redirectUrl = "/api/2014" + req.path
+  res.redirect(301, redirectUrl)
 };

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,64 +1,10 @@
-import {
-  AbilityScoresHandler,
-  AlignmentsHandler,
-  BackgroundsHandler,
-  ClassesHandler,
-  ConditionsHandler,
-  DamageTypesHandler,
-  EquipmentCategoriesHandler,
-  EquipmentHandler,
-  FeatsHandler,
-  FeaturesHandler,
-  ImageHandler,
-  LanguagesHandler,
-  MagicItemsHandler,
-  MagicSchoolsHandler,
-  MonstersHandler,
-  ProficienciesHandler,
-  RacesHandler,
-  RuleSectionsHandler,
-  RulesHandler,
-  SkillsHandler,
-  SpellsHandler,
-  SubclassesHandler,
-  SubracesHandler,
-  TraitsHandler,
-  WeaponPropertiesHandler,
-} from './api/2014/index.js';
-import V2014Handler from './api/2014.js';
-
 import express from 'express';
-import { index } from '../controllers/apiController.js';
+import deprecatedApiController from '../controllers/apiController.js'
+import v2014Handler from './api/2014.js';
 
 const router = express.Router();
 
-router.get('/', index);
-router.use('/2014', V2014Handler);
-
-router.use('/ability-scores', AbilityScoresHandler);
-router.use('/alignments', AlignmentsHandler);
-router.use('/backgrounds', BackgroundsHandler);
-router.use('/classes', ClassesHandler);
-router.use('/conditions', ConditionsHandler);
-router.use('/damage-types', DamageTypesHandler);
-router.use('/equipment-categories', EquipmentCategoriesHandler);
-router.use('/equipment', EquipmentHandler);
-router.use('/feats', FeatsHandler);
-router.use('/features', FeaturesHandler);
-router.use('/images', ImageHandler);
-router.use('/languages', LanguagesHandler);
-router.use('/magic-items', MagicItemsHandler);
-router.use('/magic-schools', MagicSchoolsHandler);
-router.use('/monsters', MonstersHandler);
-router.use('/proficiencies', ProficienciesHandler);
-router.use('/races', RacesHandler);
-router.use('/rules', RulesHandler);
-router.use('/rule-sections', RuleSectionsHandler);
-router.use('/skills', SkillsHandler);
-router.use('/spells', SpellsHandler);
-router.use('/subclasses', SubclassesHandler);
-router.use('/subraces', SubracesHandler);
-router.use('/traits', TraitsHandler);
-router.use('/weapon-properties', WeaponPropertiesHandler);
+router.use('/2014', v2014Handler);
+router.get('*', deprecatedApiController);
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,14 +44,7 @@ export default async () => {
   console.log('Setting up Apollo GraphQL server');
   const apolloMiddleware2014 = await createApolloMiddleware(schema2014);
   await apolloMiddleware2014.start();
-  app.use(
-    '/graphql',
-    cors<cors.CorsRequest>(),
-    bodyParser.json(),
-    expressMiddleware(apolloMiddleware2014, {
-      context: async ({ req }) => ({ token: req.headers.token }),
-    })
-  );
+  app.all('/graphql', (_req, res) => res.redirect(301, '/graphql/2014'));
   app.use(
     '/graphql/2014',
     cors<cors.CorsRequest>(),

--- a/src/swagger/api-spec/openapi.json
+++ b/src/swagger/api-spec/openapi.json
@@ -32,7 +32,7 @@
     }
   ],
   "paths": {
-    "/api": {
+    "/api/2014": {
       "get": {
         "summary": "Get all resource URLs.",
         "description": "Making a request to the API's base URL returns an object containing available endpoints.",
@@ -3608,6 +3608,10 @@
           },
           "url": {
             "description": "URL of the referenced resource.",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "Date and time the resource was last updated.",
             "type": "string"
           }
         }

--- a/src/swagger/api-spec/openapi.yml
+++ b/src/swagger/api-spec/openapi.yml
@@ -18,7 +18,7 @@ tags:
   - name: Common
   - name: Character Data
 paths:
-  /api:
+  /api/2014:
     get:
       summary: Get all resource URLs.
       description: Making a request to the API's base URL returns an object containing available endpoints.
@@ -2505,6 +2505,9 @@ components:
           type: string
         url:
           description: URL of the referenced resource.
+          type: string
+        updated_at:
+          description: Date and time the resource was last updated.
           type: string
     APIReferenceList:
       description: |

--- a/src/swagger/swagger.yml
+++ b/src/swagger/swagger.yml
@@ -222,7 +222,7 @@ tags:
   - name: Character Data
 
 paths:
-  /api:
+  /api/2014:
     $ref: './paths/2014/combined.yml#/base'
   /api/2014/{endpoint}:
     $ref: './paths/2014/combined.yml#/list'

--- a/src/tests/controllers/apiController.test.ts
+++ b/src/tests/controllers/apiController.test.ts
@@ -4,6 +4,7 @@ import { createRequest, createResponse } from 'node-mocks-http';
 
 import deprecatedApiController from '../../controllers/apiController.js';
 import Collection from '../../models/2014/collection/index.js';
+import { mockNext } from '../support/requestHelpers.js';
 
 describe('deprecated /api controller', () => {
   
@@ -21,7 +22,7 @@ describe('deprecated /api controller', () => {
     const response = createResponse();
     const redirect = jest.spyOn(response, 'redirect');
 
-    await deprecatedApiController(request, response);
+    await deprecatedApiController(request, response, mockNext);
     expect(response.statusCode).toBe(301);
     expect(redirect).toHaveBeenCalledWith(301, '/api/2014/');
     
@@ -32,7 +33,7 @@ describe('deprecated /api controller', () => {
     const response = createResponse();
     const redirect = jest.spyOn(response, 'redirect');
 
-    await deprecatedApiController(request, response);
+    await deprecatedApiController(request, response, mockNext);
 
     expect(response.statusCode).toBe(301);
     expect(redirect).toHaveBeenCalledWith(301, '/api/2014/valid-endpoint');
@@ -42,7 +43,7 @@ describe('deprecated /api controller', () => {
     const request = createRequest({ path: '/invalid-endpoint' });
     const response = createResponse();
 
-    await deprecatedApiController(request, response);
+    await deprecatedApiController(request, response, mockNext);
 
     expect(response.statusCode).toBe(404);
     expect(response._getData()).toBe('Not Found');

--- a/src/tests/controllers/apiController.test.ts
+++ b/src/tests/controllers/apiController.test.ts
@@ -45,6 +45,6 @@ describe('deprecated /api controller', () => {
     await deprecatedApiController(request, response);
 
     expect(response.statusCode).toBe(404);
-    expect(response._getData()).toBe("Not Found");
+    expect(response._getData()).toBe('Not Found');
   });
 });

--- a/src/tests/controllers/apiController.test.ts
+++ b/src/tests/controllers/apiController.test.ts
@@ -1,41 +1,50 @@
+import { jest } from '@jest/globals';
 import mockingoose from 'mockingoose';
 import { createRequest, createResponse } from 'node-mocks-http';
 
-import * as ApiController from '../../controllers/apiController.js';
-import { mockNext } from '../support/requestHelpers.js';
+import deprecatedApiController from '../../controllers/apiController.js';
 import Collection from '../../models/2014/collection/index.js';
 
-beforeEach(() => {
-  mockingoose.resetAll();
-});
+describe('deprecated /api controller', () => {
+  
+  beforeEach(() => {
+    mockingoose.resetAll();
 
-describe('index', () => {
-  const findDoc = [
-    {
-      index: 'a',
-    },
-    {
-      index: 'b',
-    },
-    {
-      index: 'c',
-    },
-  ];
-  const expectedResponse = {
-    '2014': '/api/2014',
-    a: '/api/a',
-    b: '/api/b',
-    c: '/api/c',
-  };
-  const request = createRequest();
-
-  it('returns the routes', async () => {
-    const response = createResponse();
+    const findDoc = [
+      { index: 'valid-endpoint' }
+    ];
     mockingoose(Collection).toReturn(findDoc, 'find');
+  })
 
-    await ApiController.index(request, response, mockNext);
+  it('redirects to /api/2014', async () => {
+    const request = createRequest({ path: '/' });
+    const response = createResponse();
+    const redirect = jest.spyOn(response, 'redirect');
 
-    expect(response.statusCode).toBe(200);
-    expect(JSON.parse(response._getData())).toStrictEqual(expectedResponse);
+    await deprecatedApiController(request, response);
+    expect(response.statusCode).toBe(301);
+    expect(redirect).toHaveBeenCalledWith(301, '/api/2014/');
+    
+  });
+
+  it('redirects nested endpoint to 2014 equivalent', async () => {
+    const request = createRequest({ path: '/valid-endpoint' });
+    const response = createResponse();
+    const redirect = jest.spyOn(response, 'redirect');
+
+    await deprecatedApiController(request, response);
+
+    expect(response.statusCode).toBe(301);
+    expect(redirect).toHaveBeenCalledWith(301, '/api/2014/valid-endpoint');
+  });
+
+  it('responds with 404 for invalid sub-routes', async () => {
+    const request = createRequest({ path: '/invalid-endpoint' });
+    const response = createResponse();
+
+    await deprecatedApiController(request, response);
+
+    expect(response.statusCode).toBe(404);
+    expect(response._getData()).toBe("Not Found");
   });
 });

--- a/src/tests/integration/api/2014/abilityScores.itest.ts
+++ b/src/tests/integration/api/2014/abilityScores.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/ability-scores', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/ability-scores');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/ability-scores?name=${name}`);
+      const res = await request(app).get(`/api/2014/ability-scores?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/ability-scores', () => {
       const indexRes = await request(app).get('/api/2014/ability-scores');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/ability-scores?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/ability-scores?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/ability-scores', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/ability-scores');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/ability-scores/${index}`);
+      const showRes = await request(app).get(`/api/2014/ability-scores/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/ability-scores', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/ability-scores/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/ability-scores/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/classes.itest.ts
+++ b/src/tests/integration/api/2014/classes.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/classes', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/classes');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/classes?name=${name}`);
+      const res = await request(app).get(`/api/2014/classes?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/classes', () => {
       const indexRes = await request(app).get('/api/2014/classes');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/classes?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/classes?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/classes', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/classes');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/classes/${index}`);
+      const showRes = await request(app).get(`/api/2014/classes/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/classes', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/classes/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/classes/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });
@@ -74,7 +74,7 @@ describe('/api/2014/classes', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/classes');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/subclasses`);
+        const res = await request(app).get(`/api/2014/classes/${index}/subclasses`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.results.length).not.toEqual(0);
       });
@@ -84,7 +84,7 @@ describe('/api/2014/classes', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/classes');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/starting-equipment`);
+        const res = await request(app).get(`/api/2014/classes/${index}/starting-equipment`);
         expect(res.statusCode).toEqual(200);
       });
     });
@@ -93,14 +93,14 @@ describe('/api/2014/classes', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/classes');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/spellcasting`);
+        const res = await request(app).get(`/api/2014/classes/${index}/spellcasting`);
         expect(res.statusCode).toEqual(200);
       });
     });
 
     describe('/api/2014/classes/:index/spells', () => {
       it('returns objects', async () => {
-        const res = await request(app).get(`/api/classes/wizard/spells`);
+        const res = await request(app).get(`/api/2014/classes/wizard/spells`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.results.length).not.toEqual(0);
       });
@@ -110,7 +110,7 @@ describe('/api/2014/classes', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/classes');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/features`);
+        const res = await request(app).get(`/api/2014/classes/${index}/features`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.results.length).not.toEqual(0);
       });
@@ -120,7 +120,7 @@ describe('/api/2014/classes', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/classes');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/proficiencies`);
+        const res = await request(app).get(`/api/2014/classes/${index}/proficiencies`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.results.length).not.toEqual(0);
       });
@@ -130,7 +130,7 @@ describe('/api/2014/classes', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/classes');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/multi-classing`);
+        const res = await request(app).get(`/api/2014/classes/${index}/multi-classing`);
         expect(res.statusCode).toEqual(200);
       });
     });
@@ -139,7 +139,7 @@ describe('/api/2014/classes', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/classes');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/levels`);
+        const res = await request(app).get(`/api/2014/classes/${index}/levels`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.length).not.toEqual(0);
         expect(res.body.length).toEqual(20);
@@ -148,9 +148,9 @@ describe('/api/2014/classes', () => {
       it('returns the subclass levels as well', async () => {
         const indexRes = await request(app).get('/api/2014/classes');
         const index = indexRes.body.results[1].index;
-        const classRes = await request(app).get(`/api/classes/${index}`);
+        const classRes = await request(app).get(`/api/2014/classes/${index}`);
         const subclass = classRes.body.subclasses[0].index;
-        const res = await request(app).get(`/api/classes/${index}/levels?subclass=${subclass}`);
+        const res = await request(app).get(`/api/2014/classes/${index}/levels?subclass=${subclass}`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.length).not.toEqual(0);
         expect(res.body.length).toBeGreaterThan(20);
@@ -161,7 +161,7 @@ describe('/api/2014/classes', () => {
           const indexRes = await request(app).get('/api/2014/classes');
           const index = indexRes.body.results[1].index;
           const level = 1;
-          const res = await request(app).get(`/api/classes/${index}/levels/${level}`);
+          const res = await request(app).get(`/api/2014/classes/${index}/levels/${level}`);
           expect(res.statusCode).toEqual(200);
           expect(res.body.level).toEqual(level);
         });
@@ -171,7 +171,7 @@ describe('/api/2014/classes', () => {
         it('returns objects', async () => {
           const index = 'wizard';
           const level = 1;
-          const res = await request(app).get(`/api/classes/${index}/levels/${level}/spells`);
+          const res = await request(app).get(`/api/2014/classes/${index}/levels/${level}/spells`);
           expect(res.statusCode).toEqual(200);
           expect(res.body.results.length).not.toEqual(0);
         });
@@ -182,7 +182,7 @@ describe('/api/2014/classes', () => {
           const indexRes = await request(app).get('/api/2014/classes');
           const index = indexRes.body.results[1].index;
           const level = 1;
-          const res = await request(app).get(`/api/classes/${index}/levels/${level}/spells`);
+          const res = await request(app).get(`/api/2014/classes/${index}/levels/${level}/spells`);
           expect(res.statusCode).toEqual(200);
           expect(res.body.results.length).not.toEqual(0);
         });

--- a/src/tests/integration/api/2014/conditions.itest.ts
+++ b/src/tests/integration/api/2014/conditions.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/conditions', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/conditions');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/conditions?name=${name}`);
+      const res = await request(app).get(`/api/2014/conditions?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/conditions', () => {
       const indexRes = await request(app).get('/api/2014/conditions');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/conditions?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/conditions?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/conditions', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/conditions');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/conditions/${index}`);
+      const showRes = await request(app).get(`/api/2014/conditions/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/conditions', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/conditions/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/conditions/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/damageTypes.itest.ts
+++ b/src/tests/integration/api/2014/damageTypes.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/damage-types', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/damage-types');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/damage-types?name=${name}`);
+      const res = await request(app).get(`/api/2014/damage-types?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/damage-types', () => {
       const indexRes = await request(app).get('/api/2014/damage-types');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/damage-types?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/damage-types?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/damage-types', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/damage-types');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/damage-types/${index}`);
+      const showRes = await request(app).get(`/api/2014/damage-types/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/damage-types', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/damage-types/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/damage-types/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/equipment.itest.ts
+++ b/src/tests/integration/api/2014/equipment.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/equipment', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/equipment');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/equipment?name=${name}`);
+      const res = await request(app).get(`/api/2014/equipment?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/equipment', () => {
       const indexRes = await request(app).get('/api/2014/equipment');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/equipment?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/equipment?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/equipment', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/equipment');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/equipment/${index}`);
+      const showRes = await request(app).get(`/api/2014/equipment/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/equipment', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/equipment/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/equipment/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/equipmentCategories.itest.ts
+++ b/src/tests/integration/api/2014/equipmentCategories.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/equipment-categories', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/equipment-categories');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/equipment-categories?name=${name}`);
+      const res = await request(app).get(`/api/2014/equipment-categories?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/equipment-categories', () => {
       const indexRes = await request(app).get('/api/2014/equipment-categories');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/equipment-categories?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/equipment-categories?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/equipment-categories', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/equipment-categories');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/equipment-categories/${index}`);
+      const showRes = await request(app).get(`/api/2014/equipment-categories/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/equipment-categories', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/equipment-categories/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/equipment-categories/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/feats.itest.ts
+++ b/src/tests/integration/api/2014/feats.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/feats', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/feats');
       const name = indexRes.body.results[0].name;
-      const res = await request(app).get(`/api/feats?name=${name}`);
+      const res = await request(app).get(`/api/2014/feats?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/feats', () => {
       const indexRes = await request(app).get('/api/2014/feats');
       const name = indexRes.body.results[0].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/feats?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/feats?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/feats', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/feats');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/feats/${index}`);
+      const showRes = await request(app).get(`/api/2014/feats/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/feats', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/feats/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/feats/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/features.itest.ts
+++ b/src/tests/integration/api/2014/features.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/features', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/features');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/features?name=${name}`);
+      const res = await request(app).get(`/api/2014/features?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/features', () => {
       const indexRes = await request(app).get('/api/2014/features');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/features?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/features?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/features', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/features');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/features/${index}`);
+      const showRes = await request(app).get(`/api/2014/features/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/features', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/features/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/features/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/languages.itest.ts
+++ b/src/tests/integration/api/2014/languages.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/languages', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/languages');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/languages?name=${name}`);
+      const res = await request(app).get(`/api/2014/languages?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/languages', () => {
       const indexRes = await request(app).get('/api/2014/languages');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/languages?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/languages?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/languages', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/languages');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/languages/${index}`);
+      const showRes = await request(app).get(`/api/2014/languages/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/languages', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/languages/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/languages/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/magicItems.itest.ts
+++ b/src/tests/integration/api/2014/magicItems.itest.ts
@@ -48,7 +48,7 @@ describe('/api/2014/magic-items', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/magic-items');
       const name = indexRes.body.results[5].name;
-      const res = await request(app).get(`/api/magic-items?name=${name}`);
+      const res = await request(app).get(`/api/2014/magic-items?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/magic-items', () => {
       const indexRes = await request(app).get('/api/2014/magic-items');
       const name = indexRes.body.results[5].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/magic-items?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/magic-items?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -67,7 +67,7 @@ describe('/api/2014/magic-items', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/magic-items');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/magic-items/${index}`);
+      const showRes = await request(app).get(`/api/2014/magic-items/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -75,7 +75,7 @@ describe('/api/2014/magic-items', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/magic-items/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/magic-items/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/magicSchools.itest.ts
+++ b/src/tests/integration/api/2014/magicSchools.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/magic-schools', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/magic-schools');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/magic-schools?name=${name}`);
+      const res = await request(app).get(`/api/2014/magic-schools?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/magic-schools', () => {
       const indexRes = await request(app).get('/api/2014/magic-schools');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/magic-schools?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/magic-schools?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/magic-schools', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/magic-schools');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/magic-schools/${index}`);
+      const showRes = await request(app).get(`/api/2014/magic-schools/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/magic-schools', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/magic-schools/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/magic-schools/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/monsters.itest.ts
+++ b/src/tests/integration/api/2014/monsters.itest.ts
@@ -48,7 +48,7 @@ describe('/api/2014/monsters', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/monsters');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/monsters?name=${name}`);
+      const res = await request(app).get(`/api/2014/monsters?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/monsters', () => {
       const indexRes = await request(app).get('/api/2014/monsters');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/monsters?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/monsters?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -67,13 +67,13 @@ describe('/api/2014/monsters', () => {
     describe('with only one provided challenge rating', () => {
       it('returns expected objects', async () => {
         const expectedCR = 0.25;
-        const res = await request(app).get(`/api/monsters?challenge_rating=${expectedCR}`);
+        const res = await request(app).get(`/api/2014/monsters?challenge_rating=${expectedCR}`);
         expect(res.statusCode).toEqual(200);
 
         const randomIndex = Math.floor(Math.random() * res.body.results.length);
         const randomResult = res.body.results[randomIndex];
 
-        const indexRes = await request(app).get(`/api/monsters/${randomResult.index}`);
+        const indexRes = await request(app).get(`/api/2014/monsters/${randomResult.index}`);
         expect(indexRes.statusCode).toEqual(200);
         expect(indexRes.body.challenge_rating).toEqual(expectedCR);
       });
@@ -82,27 +82,27 @@ describe('/api/2014/monsters', () => {
     describe('with many provided challenge ratings', () => {
       it('returns expected objects', async () => {
         const cr1 = 1;
-        const cr1Res = await request(app).get(`/api/monsters?challenge_rating=${cr1}`);
+        const cr1Res = await request(app).get(`/api/2014/monsters?challenge_rating=${cr1}`);
         expect(cr1Res.statusCode).toEqual(200);
 
         const cr20 = 20;
-        const cr20Res = await request(app).get(`/api/monsters?challenge_rating=${cr20}`);
+        const cr20Res = await request(app).get(`/api/2014/monsters?challenge_rating=${cr20}`);
         expect(cr20Res.statusCode).toEqual(200);
 
         const bothRes = await request(app).get(
-          `/api/monsters?challenge_rating=${cr1}&challenge_rating=${cr20}`
+          `/api/2014/monsters?challenge_rating=${cr1}&challenge_rating=${cr20}`
         );
         expect(bothRes.statusCode).toEqual(200);
         expect(bothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
 
-        const altBothRes = await request(app).get(`/api/monsters?challenge_rating=${cr1},${cr20}`);
+        const altBothRes = await request(app).get(`/api/2014/monsters?challenge_rating=${cr1},${cr20}`);
         expect(altBothRes.statusCode).toEqual(200);
         expect(altBothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
 
         const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
         const randomResult = bothRes.body.results[randomIndex];
 
-        const indexRes = await request(app).get(`/api/monsters/${randomResult.index}`);
+        const indexRes = await request(app).get(`/api/2014/monsters/${randomResult.index}`);
         expect(indexRes.statusCode).toEqual(200);
         expect(
           indexRes.body.challenge_rating == cr1 || indexRes.body.challenge_rating == cr20
@@ -115,7 +115,7 @@ describe('/api/2014/monsters', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/monsters');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/monsters/${index}`);
+      const showRes = await request(app).get(`/api/2014/monsters/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -123,7 +123,7 @@ describe('/api/2014/monsters', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/monsters/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/monsters/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/proficiencies.itest.ts
+++ b/src/tests/integration/api/2014/proficiencies.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/proficiencies', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/proficiencies');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/proficiencies?name=${name}`);
+      const res = await request(app).get(`/api/2014/proficiencies?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/proficiencies', () => {
       const indexRes = await request(app).get('/api/2014/proficiencies');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/proficiencies?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/proficiencies?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/proficiencies', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/proficiencies');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/proficiencies/${index}`);
+      const showRes = await request(app).get(`/api/2014/proficiencies/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/proficiencies', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/proficiencies/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/proficiencies/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/races.itest.ts
+++ b/src/tests/integration/api/2014/races.itest.ts
@@ -37,7 +37,7 @@ describe('/api/2014/races', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/races');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/races?name=${name}`);
+      const res = await request(app).get(`/api/2014/races?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -46,7 +46,7 @@ describe('/api/2014/races', () => {
       const indexRes = await request(app).get('/api/2014/races');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/races?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/races?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -56,7 +56,7 @@ describe('/api/2014/races', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/races');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/races/${index}`);
+      const showRes = await request(app).get(`/api/2014/races/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -64,7 +64,7 @@ describe('/api/2014/races', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/races/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/races/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });
@@ -73,7 +73,7 @@ describe('/api/2014/races', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/races');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/races/${index}/subraces`);
+        const res = await request(app).get(`/api/2014/races/${index}/subraces`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.results.length).not.toEqual(0);
       });
@@ -83,7 +83,7 @@ describe('/api/2014/races', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/races');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/races/${index}/proficiencies`);
+        const res = await request(app).get(`/api/2014/races/${index}/proficiencies`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.results.length).not.toEqual(0);
       });
@@ -93,7 +93,7 @@ describe('/api/2014/races', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/races');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/races/${index}/traits`);
+        const res = await request(app).get(`/api/2014/races/${index}/traits`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.results.length).not.toEqual(0);
       });

--- a/src/tests/integration/api/2014/ruleSections.itest.ts
+++ b/src/tests/integration/api/2014/ruleSections.itest.ts
@@ -48,7 +48,7 @@ describe('/api/2014/rule-sections', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/rule-sections');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/rule-sections?name=${name}`);
+      const res = await request(app).get(`/api/2014/rule-sections?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/rule-sections', () => {
       const indexRes = await request(app).get('/api/2014/rule-sections');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/rule-sections?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/rule-sections?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -67,9 +67,9 @@ describe('/api/2014/rule-sections', () => {
     it('returns the object with matching desc', async () => {
       const indexRes = await request(app).get('/api/2014/rule-sections');
       const index = indexRes.body.results[1].index;
-      const res = await request(app).get(`/api/rule-sections/${index}`);
+      const res = await request(app).get(`/api/2014/rule-sections/${index}`);
       const name = res.body.name;
-      const descRes = await request(app).get(`/api/rule-sections?desc=${name}`);
+      const descRes = await request(app).get(`/api/2014/rule-sections?desc=${name}`);
       expect(descRes.statusCode).toEqual(200);
       expect(descRes.body.results[0].index).toEqual(index);
     });
@@ -79,7 +79,7 @@ describe('/api/2014/rule-sections', () => {
       const index = indexRes.body.results[1].index;
       const name = indexRes.body.results[1].name;
       const queryDesc = name.toLowerCase();
-      const res = await request(app).get(`/api/rule-sections?desc=${queryDesc}`);
+      const res = await request(app).get(`/api/2014/rule-sections?desc=${queryDesc}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].index).toEqual(index);
     });
@@ -90,7 +90,7 @@ describe('/api/2014/rule-sections/:index', () => {
   it('should return one object', async () => {
     const indexRes = await request(app).get('/api/2014/rule-sections');
     const index = indexRes.body.results[0].index;
-    const showRes = await request(app).get(`/api/rule-sections/${index}`);
+    const showRes = await request(app).get(`/api/2014/rule-sections/${index}`);
     expect(showRes.statusCode).toEqual(200);
     expect(showRes.body.index).toEqual(index);
   });
@@ -98,7 +98,7 @@ describe('/api/2014/rule-sections/:index', () => {
   describe('with an invalid index', () => {
     it('should return 404', async () => {
       const invalidIndex = 'invalid-index';
-      const showRes = await request(app).get(`/api/rule-sections/${invalidIndex}`);
+      const showRes = await request(app).get(`/api/2014/rule-sections/${invalidIndex}`);
       expect(showRes.statusCode).toEqual(404);
     });
   });

--- a/src/tests/integration/api/2014/rules.itest.ts
+++ b/src/tests/integration/api/2014/rules.itest.ts
@@ -48,7 +48,7 @@ describe('/api/2014/rules', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/rules');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/rules?name=${name}`);
+      const res = await request(app).get(`/api/2014/rules?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/rules', () => {
       const indexRes = await request(app).get('/api/2014/rules');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/rules?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/rules?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -67,9 +67,9 @@ describe('/api/2014/rules', () => {
     it('returns the object with matching desc', async () => {
       const indexRes = await request(app).get('/api/2014/rules');
       const index = indexRes.body.results[1].index;
-      const res = await request(app).get(`/api/rules/${index}`);
+      const res = await request(app).get(`/api/2014/rules/${index}`);
       const name = res.body.name;
-      const descRes = await request(app).get(`/api/rules?desc=${name}`);
+      const descRes = await request(app).get(`/api/2014/rules?desc=${name}`);
       expect(descRes.statusCode).toEqual(200);
       expect(descRes.body.results[0].index).toEqual(index);
     });
@@ -79,7 +79,7 @@ describe('/api/2014/rules', () => {
       const index = indexRes.body.results[1].index;
       const name = indexRes.body.results[1].name;
       const queryDesc = name.toLowerCase();
-      const res = await request(app).get(`/api/rules?desc=${queryDesc}`);
+      const res = await request(app).get(`/api/2014/rules?desc=${queryDesc}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].index).toEqual(index);
     });
@@ -89,7 +89,7 @@ describe('/api/2014/rules', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/rules');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/rules/${index}`);
+      const showRes = await request(app).get(`/api/2014/rules/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -97,7 +97,7 @@ describe('/api/2014/rules', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/rules/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/rules/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/skills.itest.ts
+++ b/src/tests/integration/api/2014/skills.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/skills', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/skills');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/skills?name=${name}`);
+      const res = await request(app).get(`/api/2014/skills?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/skills', () => {
       const indexRes = await request(app).get('/api/2014/skills');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/skills?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/skills?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/skills', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/skills');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/skills/${index}`);
+      const showRes = await request(app).get(`/api/2014/skills/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/skills', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/skills/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/skills/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/spells.itest.ts
+++ b/src/tests/integration/api/2014/spells.itest.ts
@@ -48,7 +48,7 @@ describe('/api/2014/spells', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/spells');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/spells?name=${name}`);
+      const res = await request(app).get(`/api/2014/spells?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/spells', () => {
       const indexRes = await request(app).get('/api/2014/spells');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/spells?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/spells?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -66,13 +66,13 @@ describe('/api/2014/spells', () => {
   describe('with level query', () => {
     it('returns expected objects', async () => {
       const expectedLevel = 2;
-      const res = await request(app).get(`/api/spells?level=${expectedLevel}`);
+      const res = await request(app).get(`/api/2014/spells?level=${expectedLevel}`);
       expect(res.statusCode).toEqual(200);
 
       const randomIndex = Math.floor(Math.random() * res.body.results.length);
       const randomResult = res.body.results[randomIndex];
 
-      const indexRes = await request(app).get(`/api/spells/${randomResult.index}`);
+      const indexRes = await request(app).get(`/api/2014/spells/${randomResult.index}`);
       expect(indexRes.statusCode).toEqual(200);
       expect(indexRes.body.level).toEqual(expectedLevel);
     });
@@ -80,15 +80,15 @@ describe('/api/2014/spells', () => {
     describe('with many provided level', () => {
       it('returns expected objects', async () => {
         const expectedLevel1 = 1;
-        const res1 = await request(app).get(`/api/spells?level=${expectedLevel1}`);
+        const res1 = await request(app).get(`/api/2014/spells?level=${expectedLevel1}`);
         expect(res1.statusCode).toEqual(200);
 
         const expectLevel2 = 8;
-        const res2 = await request(app).get(`/api/spells?level=${expectLevel2}`);
+        const res2 = await request(app).get(`/api/2014/spells?level=${expectLevel2}`);
         expect(res2.statusCode).toEqual(200);
 
         const bothRes = await request(app).get(
-          `/api/spells?level=${expectedLevel1}&level=${expectLevel2}`
+          `/api/2014/spells?level=${expectedLevel1}&level=${expectLevel2}`
         );
         expect(bothRes.statusCode).toEqual(200);
         expect(bothRes.body.count).toEqual(res1.body.count + res2.body.count);
@@ -96,7 +96,7 @@ describe('/api/2014/spells', () => {
         const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
         const randomResult = bothRes.body.results[randomIndex];
 
-        const indexRes = await request(app).get(`/api/spells/${randomResult.index}`);
+        const indexRes = await request(app).get(`/api/2014/spells/${randomResult.index}`);
         expect(indexRes.statusCode).toEqual(200);
         expect(
           indexRes.body.level == expectedLevel1 || indexRes.body.level == expectLevel2
@@ -108,13 +108,13 @@ describe('/api/2014/spells', () => {
   describe('with school query', () => {
     it('returns expected objects', async () => {
       const expectedSchool = 'Illusion';
-      const res = await request(app).get(`/api/spells?school=${expectedSchool}`);
+      const res = await request(app).get(`/api/2014/spells?school=${expectedSchool}`);
       expect(res.statusCode).toEqual(200);
 
       const randomIndex = Math.floor(Math.random() * res.body.results.length);
       const randomResult = res.body.results[randomIndex];
 
-      const indexRes = await request(app).get(`/api/spells/${randomResult.index}`);
+      const indexRes = await request(app).get(`/api/2014/spells/${randomResult.index}`);
       expect(indexRes.statusCode).toEqual(200);
       expect(indexRes.body.school.name).toEqual(expectedSchool);
     });
@@ -122,15 +122,15 @@ describe('/api/2014/spells', () => {
     describe('with many provided schools', () => {
       it('returns expected objects', async () => {
         const expectedSchool1 = 'Illusion';
-        const res1 = await request(app).get(`/api/spells?school=${expectedSchool1}`);
+        const res1 = await request(app).get(`/api/2014/spells?school=${expectedSchool1}`);
         expect(res1.statusCode).toEqual(200);
 
         const expectedSchool2 = 'Evocation';
-        const res2 = await request(app).get(`/api/spells?school=${expectedSchool2}`);
+        const res2 = await request(app).get(`/api/2014/spells?school=${expectedSchool2}`);
         expect(res2.statusCode).toEqual(200);
 
         const bothRes = await request(app).get(
-          `/api/spells?school=${expectedSchool1}&school=${expectedSchool2}`
+          `/api/2014/spells?school=${expectedSchool1}&school=${expectedSchool2}`
         );
         expect(bothRes.statusCode).toEqual(200);
         expect(bothRes.body.count).toEqual(res1.body.count + res2.body.count);
@@ -138,7 +138,7 @@ describe('/api/2014/spells', () => {
         const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
         const randomResult = bothRes.body.results[randomIndex];
 
-        const indexRes = await request(app).get(`/api/spells/${randomResult.index}`);
+        const indexRes = await request(app).get(`/api/2014/spells/${randomResult.index}`);
         expect(indexRes.statusCode).toEqual(200);
         expect(
           indexRes.body.school.name == expectedSchool1 ||
@@ -150,15 +150,15 @@ describe('/api/2014/spells', () => {
     it('is case insensitive', async () => {
       const indexRes = await request(app).get('/api/2014/spells');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/spells/${index}`);
+      const showRes = await request(app).get(`/api/2014/spells/${index}`);
       const school = showRes.body.school.name;
       const querySchool = school.toLowerCase();
-      const res = await request(app).get(`/api/spells?school=${querySchool}`);
+      const res = await request(app).get(`/api/2014/spells?school=${querySchool}`);
 
       const randomIndex = Math.floor(Math.random() * res.body.results.length);
       const randomResult = res.body.results[randomIndex];
 
-      const queryRes = await request(app).get(`/api/spells/${randomResult.index}`);
+      const queryRes = await request(app).get(`/api/2014/spells/${randomResult.index}`);
       expect(queryRes.statusCode).toEqual(200);
       expect(queryRes.body.school.name).toEqual(school);
     });
@@ -168,7 +168,7 @@ describe('/api/2014/spells', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/spells');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/spells/${index}`);
+      const showRes = await request(app).get(`/api/2014/spells/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -176,7 +176,7 @@ describe('/api/2014/spells', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/spells/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/spells/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/subclasses.itest.ts
+++ b/src/tests/integration/api/2014/subclasses.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/subclasses', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/subclasses');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/subclasses?name=${name}`);
+      const res = await request(app).get(`/api/2014/subclasses?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/subclasses', () => {
       const indexRes = await request(app).get('/api/2014/subclasses');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/subclasses?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/subclasses?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/subclasses', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/subclasses');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/subclasses/${index}`);
+      const showRes = await request(app).get(`/api/2014/subclasses/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/subclasses', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/subclasses/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/subclasses/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });
@@ -73,7 +73,7 @@ describe('/api/2014/subclasses', () => {
     describe('/api/2014/subclasses/:index/levels', () => {
       it('returns objects', async () => {
         const index = 'berserker';
-        const res = await request(app).get(`/api/subclasses/${index}/levels`);
+        const res = await request(app).get(`/api/2014/subclasses/${index}/levels`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.length).not.toEqual(0);
       });
@@ -82,7 +82,7 @@ describe('/api/2014/subclasses', () => {
         it('returns objects', async () => {
           const index = 'berserker';
           const level = 3;
-          const res = await request(app).get(`/api/subclasses/${index}/levels/${level}`);
+          const res = await request(app).get(`/api/2014/subclasses/${index}/levels/${level}`);
           expect(res.statusCode).toEqual(200);
           expect(res.body.level).toEqual(level);
         });
@@ -91,7 +91,7 @@ describe('/api/2014/subclasses', () => {
           it('returns objects', async () => {
             const index = 'berserker';
             const level = 3;
-            const res = await request(app).get(`/api/subclasses/${index}/levels/${level}/features`);
+            const res = await request(app).get(`/api/2014/subclasses/${index}/levels/${level}/features`);
             expect(res.statusCode).toEqual(200);
             expect(res.body.results.length).not.toEqual(0);
           });

--- a/src/tests/integration/api/2014/subraces.itest.ts
+++ b/src/tests/integration/api/2014/subraces.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/subraces', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/subraces');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/subraces?name=${name}`);
+      const res = await request(app).get(`/api/2014/subraces?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/subraces', () => {
       const indexRes = await request(app).get('/api/2014/subraces');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/subraces?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/subraces?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/subraces', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/subraces');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/subraces/${index}`);
+      const showRes = await request(app).get(`/api/2014/subraces/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/subraces', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/subraces/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/subraces/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });
@@ -74,7 +74,7 @@ describe('/api/2014/subraces', () => {
       it('returns objects', async () => {
         const indexRes = await request(app).get('/api/2014/subraces');
         const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/subraces/${index}/traits`);
+        const res = await request(app).get(`/api/2014/subraces/${index}/traits`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.results.length).not.toEqual(0);
       });
@@ -82,7 +82,7 @@ describe('/api/2014/subraces', () => {
 
     describe('/api/2014/subraces/:index/proficiencies', () => {
       it('returns objects', async () => {
-        const res = await request(app).get(`/api/subraces/high-elf/proficiencies`);
+        const res = await request(app).get(`/api/2014/subraces/high-elf/proficiencies`);
         expect(res.statusCode).toEqual(200);
         expect(res.body.results.length).not.toEqual(0);
       });

--- a/src/tests/integration/api/2014/traits.itest.ts
+++ b/src/tests/integration/api/2014/traits.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/traits', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/traits');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/traits?name=${name}`);
+      const res = await request(app).get(`/api/2014/traits?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/traits', () => {
       const indexRes = await request(app).get('/api/2014/traits');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/traits?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/traits?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/traits', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/traits');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/traits/${index}`);
+      const showRes = await request(app).get(`/api/2014/traits/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/traits', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/traits/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/traits/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/2014/weaponProperties.itest.ts
+++ b/src/tests/integration/api/2014/weaponProperties.itest.ts
@@ -38,7 +38,7 @@ describe('/api/2014/weapon-properties', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/2014/weapon-properties');
       const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/weapon-properties?name=${name}`);
+      const res = await request(app).get(`/api/2014/weapon-properties?name=${name}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -47,7 +47,7 @@ describe('/api/2014/weapon-properties', () => {
       const indexRes = await request(app).get('/api/2014/weapon-properties');
       const name = indexRes.body.results[1].name;
       const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/weapon-properties?name=${queryName}`);
+      const res = await request(app).get(`/api/2014/weapon-properties?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -57,7 +57,7 @@ describe('/api/2014/weapon-properties', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/2014/weapon-properties');
       const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/weapon-properties/${index}`);
+      const showRes = await request(app).get(`/api/2014/weapon-properties/${index}`);
       expect(showRes.statusCode).toEqual(200);
       expect(showRes.body.index).toEqual(index);
     });
@@ -65,7 +65,7 @@ describe('/api/2014/weapon-properties', () => {
     describe('with an invalid index', () => {
       it('should return 404', async () => {
         const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/weapon-properties/${invalidIndex}`);
+        const showRes = await request(app).get(`/api/2014/weapon-properties/${invalidIndex}`);
         expect(showRes.statusCode).toEqual(404);
       });
     });

--- a/src/tests/integration/api/abilityScores.itest.ts
+++ b/src/tests/integration/api/abilityScores.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/ability-scores', () => {
-  it('should list ability scores', async () => {
-    const res = await request(app).get('/api/ability-scores');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/ability-scores', async () => {
+    await request(app)
+      .get('/api/ability-scores')
+      .expect(301)
+      .expect('Location', '/api/2014/ability-scores');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/ability-scores');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/ability-scores?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/ability-scores');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/ability-scores?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'CHA'
+    await request(app)
+      .get(`/api/ability-scores?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/ability-scores?name=${name}`);
   });
 
-  describe('/api/ability-scores/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/ability-scores');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/ability-scores/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/ability-scores/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/ability-scores/{index}', async () => {
+    const index = 'strength'
+    await request(app)
+      .get(`/api/ability-scores/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/ability-scores/${index}`);
   });
 });

--- a/src/tests/integration/api/classes.itest.ts
+++ b/src/tests/integration/api/classes.itest.ts
@@ -27,165 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/classes', () => {
-  it('should list classes', async () => {
-    const res = await request(app).get('/api/classes');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/classes', async () => {
+    await request(app)
+      .get('/api/classes')
+      .expect(301)
+      .expect('Location', '/api/2014/classes');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/classes');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/classes?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/classes');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/classes?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Cleric'
+    await request(app)
+      .get(`/api/classes?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/classes?name=${name}`);
   });
 
-  describe('/api/classes/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/classes');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/classes/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/classes/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
-
-    describe('/api/classes/:index/subclasses', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/classes');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/subclasses`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
-      });
-    });
-
-    describe('/api/classes/:index/starting-equipment', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/classes');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/starting-equipment`);
-        expect(res.statusCode).toEqual(200);
-      });
-    });
-
-    describe('/api/classes/:index/spellcasting', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/classes');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/spellcasting`);
-        expect(res.statusCode).toEqual(200);
-      });
-    });
-
-    describe('/api/classes/:index/spells', () => {
-      it('returns objects', async () => {
-        const res = await request(app).get(`/api/classes/wizard/spells`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
-      });
-    });
-
-    describe('/api/classes/:index/features', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/classes');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/features`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
-      });
-    });
-
-    describe('/api/classes/:index/proficiencies', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/classes');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/proficiencies`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
-      });
-    });
-
-    describe('/api/classes/:index/multi-classing', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/classes');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/multi-classing`);
-        expect(res.statusCode).toEqual(200);
-      });
-    });
-
-    describe('/api/classes/:index/levels', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/classes');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/classes/${index}/levels`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.length).not.toEqual(0);
-        expect(res.body.length).toEqual(20);
-      });
-
-      it('returns the subclass levels as well', async () => {
-        const indexRes = await request(app).get('/api/classes');
-        const index = indexRes.body.results[1].index;
-        const classRes = await request(app).get(`/api/classes/${index}`);
-        const subclass = classRes.body.subclasses[0].index;
-        const res = await request(app).get(`/api/classes/${index}/levels?subclass=${subclass}`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.length).not.toEqual(0);
-        expect(res.body.length).toBeGreaterThan(20);
-      });
-
-      describe('/api/classes/:index/levels/:level', () => {
-        it('returns objects', async () => {
-          const indexRes = await request(app).get('/api/classes');
-          const index = indexRes.body.results[1].index;
-          const level = 1;
-          const res = await request(app).get(`/api/classes/${index}/levels/${level}`);
-          expect(res.statusCode).toEqual(200);
-          expect(res.body.level).toEqual(level);
-        });
-      });
-
-      describe('/api/classes/:index/levels/:level/spells', () => {
-        it('returns objects', async () => {
-          const index = 'wizard';
-          const level = 1;
-          const res = await request(app).get(`/api/classes/${index}/levels/${level}/spells`);
-          expect(res.statusCode).toEqual(200);
-          expect(res.body.results.length).not.toEqual(0);
-        });
-      });
-
-      describe('/api/classes/:index/levels/:level/features', () => {
-        it('returns objects', async () => {
-          const indexRes = await request(app).get('/api/classes');
-          const index = indexRes.body.results[1].index;
-          const level = 1;
-          const res = await request(app).get(`/api/classes/${index}/levels/${level}/spells`);
-          expect(res.statusCode).toEqual(200);
-          expect(res.body.results.length).not.toEqual(0);
-        });
-      });
-    });
+  it('redirects to /api/2014/classes/{index}', async () => {
+    const index = 'bard'
+    await request(app)
+      .get(`/api/classes/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/classes/${index}`);
   });
 });

--- a/src/tests/integration/api/conditions.itest.ts
+++ b/src/tests/integration/api/conditions.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/conditions', () => {
-  it('should list conditions', async () => {
-    const res = await request(app).get('/api/conditions');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/conditions', async () => {
+    await request(app)
+      .get('/api/conditions')
+      .expect(301)
+      .expect('Location', '/api/2014/conditions');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/conditions');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/conditions?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/conditions');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/conditions?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Blinded'
+    await request(app)
+      .get(`/api/conditions?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/conditions?name=${name}`);
   });
 
-  describe('/api/conditions/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/conditions');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/conditions/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/conditions/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/conditions/{index}', async () => {
+    const index = 'charmed'
+    await request(app)
+      .get(`/api/conditions/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/conditions/${index}`);
   });
 });

--- a/src/tests/integration/api/damageTypes.itest.ts
+++ b/src/tests/integration/api/damageTypes.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/damage-types', () => {
-  it('should list damage types', async () => {
-    const res = await request(app).get('/api/damage-types');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/damage-types', async () => {
+    await request(app)
+      .get('/api/damage-types')
+      .expect(301)
+      .expect('Location', '/api/2014/damage-types');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/damage-types');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/damage-types?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/damage-types');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/damage-types?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Acid'
+    await request(app)
+      .get(`/api/damage-types?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/damage-types?name=${name}`);
   });
 
-  describe('/api/damage-types/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/damage-types');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/damage-types/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/damage-types/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/damage-types/{index}', async () => {
+    const index = 'cold'
+    await request(app)
+      .get(`/api/damage-types/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/damage-types/${index}`);
   });
 });

--- a/src/tests/integration/api/equipment.itest.ts
+++ b/src/tests/integration/api/equipment.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/equipment', () => {
-  it('should list equipment', async () => {
-    const res = await request(app).get('/api/equipment');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/equipment', async () => {
+    await request(app)
+      .get('/api/equipment')
+      .expect(301)
+      .expect('Location', '/api/2014/equipment');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/equipment');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/equipment?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/equipment');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/equipment?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Abacus'
+    await request(app)
+      .get(`/api/equipment?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/equipment?name=${name}`);
   });
 
-  describe('/api/equipment/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/equipment');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/equipment/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/equipment/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/equipment/{index}', async () => {
+    const index = 'acid-vial'
+    await request(app)
+      .get(`/api/equipment/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/equipment/${index}`);
   });
 });

--- a/src/tests/integration/api/equipmentCategories.itest.ts
+++ b/src/tests/integration/api/equipmentCategories.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/equipment-categories', () => {
-  it('should list equipment categories', async () => {
-    const res = await request(app).get('/api/equipment-categories');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/equipment-categories', async () => {
+    await request(app)
+      .get('/api/equipment-categories')
+      .expect(301)
+      .expect('Location', '/api/2014/equipment-categories');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/equipment-categories');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/equipment-categories?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/equipment-categories');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/equipment-categories?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Adventuring%20Gear'
+    await request(app)
+      .get(`/api/equipment-categories?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/equipment-categories?name=${name}`);
   });
 
-  describe('/api/equipment-categories/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/equipment-categories');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/equipment-categories/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/equipment-categories/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/equipment-categories/{index}', async () => {
+    const index = 'ammunition'
+    await request(app)
+      .get(`/api/equipment-categories/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/equipment-categories/${index}`);
   });
 });

--- a/src/tests/integration/api/feats.itest.ts
+++ b/src/tests/integration/api/feats.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/feats', () => {
-  it('should list feats', async () => {
-    const res = await request(app).get('/api/feats');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
-  });
-
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/feats');
-      const name = indexRes.body.results[0].name;
-      const res = await request(app).get(`/api/feats?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
+  it('redirects to /api/2014/feats', async () => {
+      await request(app)
+        .get('/api/feats')
+        .expect(301)
+        .expect('Location', '/api/2014/feats');
     });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/feats');
-      const name = indexRes.body.results[0].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/feats?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
+  
+    it('redirects preserving query parameters', async () => {
+      const name = 'Grappler'
+      await request(app)
+        .get(`/api/feats?name=${name}`)
+        .expect(301)
+        .expect('Location', `/api/2014/feats?name=${name}`);
     });
-  });
-
-  describe('/api/feats/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/feats');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/feats/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
+  
+    it('redirects to /api/2014/feats/{index}', async () => {
+      const index = 'grappler'
+      await request(app)
+        .get(`/api/feats/${index}`)
+        .expect(301)
+        .expect('Location', `/api/2014/feats/${index}`);
     });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/feats/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
-  });
 });

--- a/src/tests/integration/api/features.itest.ts
+++ b/src/tests/integration/api/features.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/features', () => {
-  it('should list features', async () => {
-    const res = await request(app).get('/api/features');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/features', async () => {
+    await request(app)
+      .get('/api/features')
+      .expect(301)
+      .expect('Location', '/api/2014/features');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/features');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/features?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/features');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/features?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Action%20Surge'
+    await request(app)
+      .get(`/api/features?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/features?name=${name}`);
   });
 
-  describe('/api/features/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/features');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/features/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/features/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/features/{index}', async () => {
+    const index = 'arcane-recovery'
+    await request(app)
+      .get(`/api/features/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/features/${index}`);
   });
 });

--- a/src/tests/integration/api/languages.itest.ts
+++ b/src/tests/integration/api/languages.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/languages', () => {
-  it('should list languages', async () => {
-    const res = await request(app).get('/api/languages');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/languages', async () => {
+    await request(app)
+      .get('/api/languages')
+      .expect(301)
+      .expect('Location', '/api/2014/languages');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/languages');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/languages?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/languages');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/languages?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Abyssal'
+    await request(app)
+      .get(`/api/languages?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/languages?name=${name}`);
   });
 
-  describe('/api/languages/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/languages');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/languages/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/languages/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/languages/{index}', async () => {
+    const index = 'celestial'
+    await request(app)
+      .get(`/api/languages/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/languages/${index}`);
   });
 });

--- a/src/tests/integration/api/magicItems.itest.ts
+++ b/src/tests/integration/api/magicItems.itest.ts
@@ -27,56 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/magic-items', () => {
-  it('should list magic items', async () => {
-    const res = await request(app).get('/api/magic-items');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/magic-items', async () => {
+    await request(app)
+      .get('/api/magic-items')
+      .expect(301)
+      .expect('Location', '/api/2014/magic-items');
   });
 
-  it('should hit the cache', async () => {
-    await redisClient.del('/api/magic-items');
-    const clientSet = jest.spyOn(redisClient, 'set');
-    let res = await request(app).get('/api/magic-items');
-    res = await request(app).get('/api/magic-items');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
-    expect(clientSet).toHaveBeenCalledTimes(1);
+  it('redirects preserving query parameters', async () => {
+    const name = 'Adamantine%20Armor'
+    await request(app)
+      .get(`/api/magic-items?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/magic-items?name=${name}`);
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/magic-items');
-      const name = indexRes.body.results[5].name;
-      const res = await request(app).get(`/api/magic-items?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/magic-items');
-      const name = indexRes.body.results[5].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/magic-items?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-  });
-
-  describe('/api/magic-items/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/magic-items');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/magic-items/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/magic-items/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/magic-items/{index}', async () => {
+    const index = 'ammunition'
+    await request(app)
+      .get(`/api/magic-items/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/magic-items/${index}`);
   });
 });

--- a/src/tests/integration/api/magicSchools.itest.ts
+++ b/src/tests/integration/api/magicSchools.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/magic-schools', () => {
-  it('should list magic items', async () => {
-    const res = await request(app).get('/api/magic-schools');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/magic-schools', async () => {
+    await request(app)
+      .get('/api/magic-schools')
+      .expect(301)
+      .expect('Location', '/api/2014/magic-schools');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/magic-schools');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/magic-schools?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/magic-schools');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/magic-schools?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Abjuration'
+    await request(app)
+      .get(`/api/magic-schools?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/magic-schools?name=${name}`);
   });
 
-  describe('/api/magic-schools/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/magic-schools');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/magic-schools/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/magic-schools/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/magic-schools/{index}', async () => {
+    const index = 'conjuration'
+    await request(app)
+      .get(`/api/magic-schools/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/magic-schools/${index}`);
   });
 });

--- a/src/tests/integration/api/monsters.itest.ts
+++ b/src/tests/integration/api/monsters.itest.ts
@@ -27,104 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/monsters', () => {
-  it('should list monsters', async () => {
-    const res = await request(app).get('/api/monsters');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/monsters', async () => {
+    await request(app)
+      .get('/api/monsters')
+      .expect(301)
+      .expect('Location', '/api/2014/monsters');
   });
 
-  it('should hit the cache', async () => {
-    await redisClient.del('/api/monsters');
-    const clientSet = jest.spyOn(redisClient, 'set');
-    let res = await request(app).get('/api/monsters');
-    res = await request(app).get('/api/monsters');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
-    expect(clientSet).toHaveBeenCalledTimes(1);
+  it('redirects preserving query parameters', async () => {
+    const name = 'Aboleth'
+    await request(app)
+      .get(`/api/monsters?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/monsters?name=${name}`);
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/monsters');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/monsters?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/monsters');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/monsters?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-  });
-
-  describe('with challenge_rating query', () => {
-    describe('with only one provided challenge rating', () => {
-      it('returns expected objects', async () => {
-        const expectedCR = 0.25;
-        const res = await request(app).get(`/api/monsters?challenge_rating=${expectedCR}`);
-        expect(res.statusCode).toEqual(200);
-
-        const randomIndex = Math.floor(Math.random() * res.body.results.length);
-        const randomResult = res.body.results[randomIndex];
-
-        const indexRes = await request(app).get(`/api/monsters/${randomResult.index}`);
-        expect(indexRes.statusCode).toEqual(200);
-        expect(indexRes.body.challenge_rating).toEqual(expectedCR);
-      });
-    });
-
-    describe('with many provided challenge ratings', () => {
-      it('returns expected objects', async () => {
-        const cr1 = 1;
-        const cr1Res = await request(app).get(`/api/monsters?challenge_rating=${cr1}`);
-        expect(cr1Res.statusCode).toEqual(200);
-
-        const cr20 = 20;
-        const cr20Res = await request(app).get(`/api/monsters?challenge_rating=${cr20}`);
-        expect(cr20Res.statusCode).toEqual(200);
-
-        const bothRes = await request(app).get(
-          `/api/monsters?challenge_rating=${cr1}&challenge_rating=${cr20}`
-        );
-        expect(bothRes.statusCode).toEqual(200);
-        expect(bothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
-
-        const altBothRes = await request(app).get(`/api/monsters?challenge_rating=${cr1},${cr20}`);
-        expect(altBothRes.statusCode).toEqual(200);
-        expect(altBothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
-
-        const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
-        const randomResult = bothRes.body.results[randomIndex];
-
-        const indexRes = await request(app).get(`/api/monsters/${randomResult.index}`);
-        expect(indexRes.statusCode).toEqual(200);
-        expect(
-          indexRes.body.challenge_rating == cr1 || indexRes.body.challenge_rating == cr20
-        ).toBeTruthy();
-      });
-    });
-  });
-
-  describe('/api/monsters/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/monsters');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/monsters/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/monsters/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/monsters/{index}', async () => {
+    const index = 'acolyte'
+    await request(app)
+      .get(`/api/monsters/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/monsters/${index}`);
   });
 });

--- a/src/tests/integration/api/proficiencies.itest.ts
+++ b/src/tests/integration/api/proficiencies.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/proficiencies', () => {
-  it('should list proficiencies', async () => {
-    const res = await request(app).get('/api/proficiencies');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/proficiencies', async () => {
+    await request(app)
+      .get('/api/proficiencies')
+      .expect(301)
+      .expect('Location', '/api/2014/proficiencies');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/proficiencies');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/proficiencies?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/proficiencies');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/proficiencies?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Bagpipes'
+    await request(app)
+      .get(`/api/proficiencies?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/proficiencies?name=${name}`);
   });
 
-  describe('/api/proficiencies/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/proficiencies');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/proficiencies/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/proficiencies/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/proficiencies/{index}', async () => {
+    const index = 'blowguns'
+    await request(app)
+      .get(`/api/proficiencies/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/proficiencies/${index}`);
   });
 });

--- a/src/tests/integration/api/races.itest.ts
+++ b/src/tests/integration/api/races.itest.ts
@@ -27,76 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/races', () => {
-  it('should list races', async () => {
-    const res = await request(app).get('/api/races');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/races', async () => {
+    await request(app)
+      .get('/api/races')
+      .expect(301)
+      .expect('Location', '/api/2014/races');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/races');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/races?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/races');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/races?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Dragonborn'
+    await request(app)
+      .get(`/api/races?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/races?name=${name}`);
   });
 
-  describe('/api/races/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/races');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/races/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/races/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
-
-    describe('/api/races/:index/subraces', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/races');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/races/${index}/subraces`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
-      });
-    });
-
-    describe('/api/races/:index/proficiencies', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/races');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/races/${index}/proficiencies`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
-      });
-    });
-
-    describe('/api/races/:index/traits', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/races');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/races/${index}/traits`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
-      });
-    });
+  it('redirects to /api/2014/races/{index}', async () => {
+    const index = 'dwarf'
+    await request(app)
+      .get(`/api/races/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/races/${index}`);
   });
 });

--- a/src/tests/integration/api/ruleSections.itest.ts
+++ b/src/tests/integration/api/ruleSections.itest.ts
@@ -27,78 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/rule-sections', () => {
-  it('should list rule sections', async () => {
-    const res = await request(app).get('/api/rule-sections');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/rule-sections', async () => {
+    await request(app)
+      .get('/api/rule-sections')
+      .expect(301)
+      .expect('Location', '/api/2014/rule-sections');
   });
 
-  it('should hit the cache', async () => {
-    await redisClient.del('/api/rule-sections');
-    const clientSet = jest.spyOn(redisClient, 'set');
-    let res = await request(app).get('/api/rule-sections');
-    res = await request(app).get('/api/rule-sections');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
-    expect(clientSet).toHaveBeenCalledTimes(1);
+  it('redirects preserving query parameters', async () => {
+    const name = 'Ability%20Checks'
+    await request(app)
+      .get(`/api/rule-sections?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/rule-sections?name=${name}`);
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/rule-sections');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/rule-sections?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/rule-sections');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/rule-sections?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-  });
-
-  describe('with desc query', () => {
-    it('returns the object with matching desc', async () => {
-      const indexRes = await request(app).get('/api/rule-sections');
-      const index = indexRes.body.results[1].index;
-      const res = await request(app).get(`/api/rule-sections/${index}`);
-      const name = res.body.name;
-      const descRes = await request(app).get(`/api/rule-sections?desc=${name}`);
-      expect(descRes.statusCode).toEqual(200);
-      expect(descRes.body.results[0].index).toEqual(index);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/rule-sections');
-      const index = indexRes.body.results[1].index;
-      const name = indexRes.body.results[1].name;
-      const queryDesc = name.toLowerCase();
-      const res = await request(app).get(`/api/rule-sections?desc=${queryDesc}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].index).toEqual(index);
-    });
-  });
-});
-
-describe('/api/rule-sections/:index', () => {
-  it('should return one object', async () => {
-    const indexRes = await request(app).get('/api/rule-sections');
-    const index = indexRes.body.results[0].index;
-    const showRes = await request(app).get(`/api/rule-sections/${index}`);
-    expect(showRes.statusCode).toEqual(200);
-    expect(showRes.body.index).toEqual(index);
-  });
-
-  describe('with an invalid index', () => {
-    it('should return 404', async () => {
-      const invalidIndex = 'invalid-index';
-      const showRes = await request(app).get(`/api/rule-sections/${invalidIndex}`);
-      expect(showRes.statusCode).toEqual(404);
-    });
+  it('redirects to /api/2014/rule-sections/{index}', async () => {
+    const index = 'actions-in-combat'
+    await request(app)
+      .get(`/api/rule-sections/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/rule-sections/${index}`);
   });
 });

--- a/src/tests/integration/api/rules.itest.ts
+++ b/src/tests/integration/api/rules.itest.ts
@@ -27,78 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/rules', () => {
-  it('should list rules', async () => {
-    const res = await request(app).get('/api/rules');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/rules', async () => {
+    await request(app)
+      .get('/api/rules')
+      .expect(301)
+      .expect('Location', '/api/2014/rules');
   });
 
-  it('should hit the cache', async () => {
-    await redisClient.del('/api/rules');
-    const clientSet = jest.spyOn(redisClient, 'set');
-    let res = await request(app).get('/api/rules');
-    res = await request(app).get('/api/rules');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
-    expect(clientSet).toHaveBeenCalledTimes(1);
+  it('redirects preserving query parameters', async () => {
+    const name = 'Adventuring'
+    await request(app)
+      .get(`/api/rules?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/rules?name=${name}`);
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/rules');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/rules?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/rules');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/rules?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-  });
-
-  describe('with desc query', () => {
-    it('returns the object with matching desc', async () => {
-      const indexRes = await request(app).get('/api/rules');
-      const index = indexRes.body.results[1].index;
-      const res = await request(app).get(`/api/rules/${index}`);
-      const name = res.body.name;
-      const descRes = await request(app).get(`/api/rules?desc=${name}`);
-      expect(descRes.statusCode).toEqual(200);
-      expect(descRes.body.results[0].index).toEqual(index);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/rules');
-      const index = indexRes.body.results[1].index;
-      const name = indexRes.body.results[1].name;
-      const queryDesc = name.toLowerCase();
-      const res = await request(app).get(`/api/rules?desc=${queryDesc}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].index).toEqual(index);
-    });
-  });
-
-  describe('/api/rules/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/rules');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/rules/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/rules/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/rules/{index}', async () => {
+    const index = 'appendix'
+    await request(app)
+      .get(`/api/rules/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/rules/${index}`);
   });
 });

--- a/src/tests/integration/api/skills.itest.ts
+++ b/src/tests/integration/api/skills.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/skills', () => {
-  it('should list skills', async () => {
-    const res = await request(app).get('/api/skills');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
-  });
-
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/skills');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/skills?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
+  it('redirects to /api/2014/skills', async () => {
+      await request(app)
+        .get('/api/skills')
+        .expect(301)
+        .expect('Location', '/api/2014/skills');
     });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/skills');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/skills?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
+  
+    it('redirects preserving query parameters', async () => {
+      const name = 'Acrobatics'
+      await request(app)
+        .get(`/api/skills?name=${name}`)
+        .expect(301)
+        .expect('Location', `/api/2014/skills?name=${name}`);
     });
-  });
-
-  describe('/api/skills/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/skills');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/skills/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
+  
+    it('redirects to /api/2014/skills/{index}', async () => {
+      const index = 'arcana'
+      await request(app)
+        .get(`/api/skills/${index}`)
+        .expect(301)
+        .expect('Location', `/api/2014/skills/${index}`);
     });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/skills/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
-  });
 });

--- a/src/tests/integration/api/spells.itest.ts
+++ b/src/tests/integration/api/spells.itest.ts
@@ -27,157 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/spells', () => {
-  it('should list spells', async () => {
-    const res = await request(app).get('/api/spells');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/spells', async () => {
+    await request(app)
+      .get('/api/spells')
+      .expect(301)
+      .expect('Location', '/api/2014/spells');
   });
 
-  it('should hit the cache', async () => {
-    await redisClient.del('/api/spells');
-    const clientSet = jest.spyOn(redisClient, 'set');
-    let res = await request(app).get('/api/spells');
-    res = await request(app).get('/api/spells');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
-    expect(clientSet).toHaveBeenCalledTimes(1);
+  it('redirects preserving query parameters', async () => {
+    const name = 'Acid%20Arrow'
+    await request(app)
+      .get(`/api/spells?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/spells?name=${name}`);
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/spells');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/spells?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/spells');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/spells?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-  });
-
-  describe('with level query', () => {
-    it('returns expected objects', async () => {
-      const expectedLevel = 2;
-      const res = await request(app).get(`/api/spells?level=${expectedLevel}`);
-      expect(res.statusCode).toEqual(200);
-
-      const randomIndex = Math.floor(Math.random() * res.body.results.length);
-      const randomResult = res.body.results[randomIndex];
-
-      const indexRes = await request(app).get(`/api/spells/${randomResult.index}`);
-      expect(indexRes.statusCode).toEqual(200);
-      expect(indexRes.body.level).toEqual(expectedLevel);
-    });
-
-    describe('with many provided level', () => {
-      it('returns expected objects', async () => {
-        const expectedLevel1 = 1;
-        const res1 = await request(app).get(`/api/spells?level=${expectedLevel1}`);
-        expect(res1.statusCode).toEqual(200);
-
-        const expectLevel2 = 8;
-        const res2 = await request(app).get(`/api/spells?level=${expectLevel2}`);
-        expect(res2.statusCode).toEqual(200);
-
-        const bothRes = await request(app).get(
-          `/api/spells?level=${expectedLevel1}&level=${expectLevel2}`
-        );
-        expect(bothRes.statusCode).toEqual(200);
-        expect(bothRes.body.count).toEqual(res1.body.count + res2.body.count);
-
-        const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
-        const randomResult = bothRes.body.results[randomIndex];
-
-        const indexRes = await request(app).get(`/api/spells/${randomResult.index}`);
-        expect(indexRes.statusCode).toEqual(200);
-        expect(
-          indexRes.body.level == expectedLevel1 || indexRes.body.level == expectLevel2
-        ).toBeTruthy();
-      });
-    });
-  });
-
-  describe('with school query', () => {
-    it('returns expected objects', async () => {
-      const expectedSchool = 'Illusion';
-      const res = await request(app).get(`/api/spells?school=${expectedSchool}`);
-      expect(res.statusCode).toEqual(200);
-
-      const randomIndex = Math.floor(Math.random() * res.body.results.length);
-      const randomResult = res.body.results[randomIndex];
-
-      const indexRes = await request(app).get(`/api/spells/${randomResult.index}`);
-      expect(indexRes.statusCode).toEqual(200);
-      expect(indexRes.body.school.name).toEqual(expectedSchool);
-    });
-
-    describe('with many provided schools', () => {
-      it('returns expected objects', async () => {
-        const expectedSchool1 = 'Illusion';
-        const res1 = await request(app).get(`/api/spells?school=${expectedSchool1}`);
-        expect(res1.statusCode).toEqual(200);
-
-        const expectedSchool2 = 'Evocation';
-        const res2 = await request(app).get(`/api/spells?school=${expectedSchool2}`);
-        expect(res2.statusCode).toEqual(200);
-
-        const bothRes = await request(app).get(
-          `/api/spells?school=${expectedSchool1}&school=${expectedSchool2}`
-        );
-        expect(bothRes.statusCode).toEqual(200);
-        expect(bothRes.body.count).toEqual(res1.body.count + res2.body.count);
-
-        const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
-        const randomResult = bothRes.body.results[randomIndex];
-
-        const indexRes = await request(app).get(`/api/spells/${randomResult.index}`);
-        expect(indexRes.statusCode).toEqual(200);
-        expect(
-          indexRes.body.school.name == expectedSchool1 ||
-            indexRes.body.school.name == expectedSchool2
-        ).toBeTruthy();
-      });
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/spells');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/spells/${index}`);
-      const school = showRes.body.school.name;
-      const querySchool = school.toLowerCase();
-      const res = await request(app).get(`/api/spells?school=${querySchool}`);
-
-      const randomIndex = Math.floor(Math.random() * res.body.results.length);
-      const randomResult = res.body.results[randomIndex];
-
-      const queryRes = await request(app).get(`/api/spells/${randomResult.index}`);
-      expect(queryRes.statusCode).toEqual(200);
-      expect(queryRes.body.school.name).toEqual(school);
-    });
-  });
-
-  describe('/api/spells/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/spells');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/spells/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/spells/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/spells/{index}', async () => {
+    const index = 'aid'
+    await request(app)
+      .get(`/api/spells/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/spells/${index}`);
   });
 });

--- a/src/tests/integration/api/subclasses.itest.ts
+++ b/src/tests/integration/api/subclasses.itest.ts
@@ -27,75 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/subclasses', () => {
-  it('should list subclasses', async () => {
-    const res = await request(app).get('/api/subclasses');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
-  });
-
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/subclasses');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/subclasses?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
+  it('redirects to /api/2014/subclasses', async () => {
+      await request(app)
+        .get('/api/subclasses')
+        .expect(301)
+        .expect('Location', '/api/2014/subclasses');
     });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/subclasses');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/subclasses?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
+  
+    it('redirects preserving query parameters', async () => {
+      const name = 'Berserker'
+      await request(app)
+        .get(`/api/subclasses?name=${name}`)
+        .expect(301)
+        .expect('Location', `/api/2014/subclasses?name=${name}`);
     });
-  });
-
-  describe('/api/subclasses/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/subclasses');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/subclasses/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
+  
+    it('redirects to /api/2014/subclasses/{index}', async () => {
+      const index = 'Champion'
+      await request(app)
+        .get(`/api/subclasses/${index}`)
+        .expect(301)
+        .expect('Location', `/api/2014/subclasses/${index}`);
     });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/subclasses/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
-
-    describe('/api/subclasses/:index/levels', () => {
-      it('returns objects', async () => {
-        const index = 'berserker';
-        const res = await request(app).get(`/api/subclasses/${index}/levels`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.length).not.toEqual(0);
-      });
-
-      describe('/api/subclasses/:index/levels/:level', () => {
-        it('returns objects', async () => {
-          const index = 'berserker';
-          const level = 3;
-          const res = await request(app).get(`/api/subclasses/${index}/levels/${level}`);
-          expect(res.statusCode).toEqual(200);
-          expect(res.body.level).toEqual(level);
-        });
-
-        describe('/api/subclasses/:index/levels/:level/features', () => {
-          it('returns objects', async () => {
-            const index = 'berserker';
-            const level = 3;
-            const res = await request(app).get(`/api/subclasses/${index}/levels/${level}/features`);
-            expect(res.statusCode).toEqual(200);
-            expect(res.body.results.length).not.toEqual(0);
-          });
-        });
-      });
-    });
-  });
 });

--- a/src/tests/integration/api/subraces.itest.ts
+++ b/src/tests/integration/api/subraces.itest.ts
@@ -27,64 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/subraces', () => {
-  it('should list subraces', async () => {
-    const res = await request(app).get('/api/subraces');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/subraces', async () => {
+    await request(app)
+      .get('/api/subraces')
+      .expect(301)
+      .expect('Location', '/api/2014/subraces');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/subraces');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/subraces?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/subraces');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/subraces?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'High%20Elf'
+    await request(app)
+      .get(`/api/subraces?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/subraces?name=${name}`);
   });
 
-  describe('/api/subraces/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/subraces');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/subraces/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/subraces/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
-
-    describe('/api/subraces/:index/traits', () => {
-      it('returns objects', async () => {
-        const indexRes = await request(app).get('/api/subraces');
-        const index = indexRes.body.results[1].index;
-        const res = await request(app).get(`/api/subraces/${index}/traits`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
-      });
-    });
-
-    describe('/api/subraces/:index/proficiencies', () => {
-      it('returns objects', async () => {
-        const res = await request(app).get(`/api/subraces/high-elf/proficiencies`);
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.results.length).not.toEqual(0);
-      });
-    });
+  it('redirects to /api/2014/subraces/{index}', async () => {
+    const index = 'hill-dwarf'
+    await request(app)
+      .get(`/api/subraces/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/subraces/${index}`);
   });
 });

--- a/src/tests/integration/api/traits.itest.ts
+++ b/src/tests/integration/api/traits.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/traits', () => {
-  it('should list traits', async () => {
-    const res = await request(app).get('/api/traits');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
-  });
-
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/traits');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/traits?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
+  it('redirects to /api/2014/traits', async () => {
+      await request(app)
+        .get('/api/traits')
+        .expect(301)
+        .expect('Location', '/api/2014/traits');
     });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/traits');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/traits?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
+  
+    it('redirects preserving query parameters', async () => {
+      const name = 'Brave'
+      await request(app)
+        .get(`/api/traits?name=${name}`)
+        .expect(301)
+        .expect('Location', `/api/2014/traits?name=${name}`);
     });
-  });
-
-  describe('/api/traits/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/traits');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/traits/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
+  
+    it('redirects to /api/2014/traits/{index}', async () => {
+      const index = 'darkvision'
+      await request(app)
+        .get(`/api/traits/${index}`)
+        .expect(301)
+        .expect('Location', `/api/2014/traits/${index}`);
     });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/traits/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
-  });
 });

--- a/src/tests/integration/api/weaponProperties.itest.ts
+++ b/src/tests/integration/api/weaponProperties.itest.ts
@@ -27,46 +27,26 @@ afterAll(async () => {
 });
 
 describe('/api/weapon-properties', () => {
-  it('should list weapon properties', async () => {
-    const res = await request(app).get('/api/weapon-properties');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body.results.length).not.toEqual(0);
+  it('redirects to /api/2014/weapon-properties', async () => {
+    await request(app)
+      .get('/api/weapon-properties')
+      .expect(301)
+      .expect('Location', '/api/2014/weapon-properties');
   });
 
-  describe('with name query', () => {
-    it('returns the named object', async () => {
-      const indexRes = await request(app).get('/api/weapon-properties');
-      const name = indexRes.body.results[1].name;
-      const res = await request(app).get(`/api/weapon-properties?name=${name}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
-
-    it('is case insensitive', async () => {
-      const indexRes = await request(app).get('/api/weapon-properties');
-      const name = indexRes.body.results[1].name;
-      const queryName = name.toLowerCase();
-      const res = await request(app).get(`/api/weapon-properties?name=${queryName}`);
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].name).toEqual(name);
-    });
+  it('redirects preserving query parameters', async () => {
+    const name = 'Ammunition'
+    await request(app)
+      .get(`/api/weapon-properties?name=${name}`)
+      .expect(301)
+      .expect('Location', `/api/2014/weapon-properties?name=${name}`);
   });
 
-  describe('/api/weapon-properties/:index', () => {
-    it('should return one object', async () => {
-      const indexRes = await request(app).get('/api/weapon-properties');
-      const index = indexRes.body.results[0].index;
-      const showRes = await request(app).get(`/api/weapon-properties/${index}`);
-      expect(showRes.statusCode).toEqual(200);
-      expect(showRes.body.index).toEqual(index);
-    });
-
-    describe('with an invalid index', () => {
-      it('should return 404', async () => {
-        const invalidIndex = 'invalid-index';
-        const showRes = await request(app).get(`/api/weapon-properties/${invalidIndex}`);
-        expect(showRes.statusCode).toEqual(404);
-      });
-    });
+  it('redirects to /api/2014/weapon-properties/{index}', async () => {
+    const index = 'finesse'
+    await request(app)
+      .get(`/api/weapon-properties/${index}`)
+      .expect(301)
+      .expect('Location', `/api/2014/weapon-properties/${index}`);
   });
 });

--- a/src/tests/integration/server.itest.ts
+++ b/src/tests/integration/server.itest.ts
@@ -48,11 +48,11 @@ describe('/bad-url', () => {
 });
 
 describe('/api', () => {
-  it('should list the endpoints', async () => {
-    const res = await request(app).get('/api');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body).toHaveProperty('ability-scores');
-    expect(res.body).not.toHaveProperty('levels');
+  it('should redirect to /api/2014', async () => {
+    await request(app)
+      .get('/api')
+      .expect(301)
+      .expect('Location', '/api/2014/');
   });
 });
 


### PR DESCRIPTION
## What does this do?
Adds a permanent redirect (HTTP 301) to `/api/*` routes, pointing to the corresponding `/api/2014/*` route.

## How was it tested?
Manual testing in local docker container. Unit & integration tests updated to ensure 301 status code and `res.redirect` is called when appropriate.

## Is there a Github issue this is resolving?
No.

## Was any impacted documentation updated to reflect this change?
Yes. Replaced `/api` path in `swagger.yml` with `/api/2014`.

## Here's a fun image for your troubles
![A repotted plant with caption "301 Moved Permanently"](https://http.garden/301.jpg)
