### PR TITLE
fix: :bug: update some missed unversioned /api paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npm run dev
 Request the image by navigating to an image URL in a browser, or via HTTP request:
 
 ```shell
-curl http://localhost:3000/api/monsters/aboleth.png --output downloaded-aboleth.png
+curl http://localhost:3000/api/2014/monsters/aboleth.png --output downloaded-aboleth.png
 ```
 
 When interacting with the image you should see logs in the terminal where you started localstack. You can also use [localstack's webui](https://app.localstack.cloud/dashboard) to view the bucket and

--- a/src/controllers/api/2014/classController.ts
+++ b/src/controllers/api/2014/classController.ts
@@ -24,7 +24,7 @@ export const show = async (req: Request, res: Response, next: NextFunction) =>
 export const showLevelsForClass = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const searchQueries: ShowLevelsForClassQuery = {
-      'class.url': '/api/classes/' + req.params.index,
+      'class.url': '/api/2014/classes/' + req.params.index,
       $or: [{ subclass: null }],
     };
 
@@ -51,7 +51,7 @@ export const showLevelForClass = async (req: Request, res: Response, next: NextF
       return res.status(404).json({ error: 'Not found' });
     }
 
-    const urlString = '/api/classes/' + req.params.index + '/levels/' + req.params.level;
+    const urlString = '/api/2014/classes/' + req.params.index + '/levels/' + req.params.level;
 
     const data = await Level.findOne({ url: urlString });
     if (!data) return next();
@@ -67,7 +67,7 @@ export const showMulticlassingForClass = async (
   next: NextFunction
 ) => {
   try {
-    const urlString = '/api/classes/' + req.params.index;
+    const urlString = '/api/2014/classes/' + req.params.index;
 
     const data = await Class.findOne({ url: urlString });
     return res.status(200).json(data?.multi_classing);
@@ -78,7 +78,7 @@ export const showMulticlassingForClass = async (
 
 export const showSubclassesForClass = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const urlString = '/api/classes/' + req.params.index;
+    const urlString = '/api/2014/classes/' + req.params.index;
 
     const data = await Subclass.find({ 'class.url': urlString })
       .select({ index: 1, name: 1, url: 1, _id: 0 })
@@ -124,7 +124,7 @@ export const showSpellcastingForClass = async (req: Request, res: Response, next
 
 export const showSpellsForClass = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const urlString = '/api/classes/' + req.params.index;
+    const urlString = '/api/2014/classes/' + req.params.index;
 
     const data = await Spell.find({ 'classes.url': urlString })
       .select({ index: 1, level: 1, name: 1, url: 1, _id: 0 })
@@ -145,7 +145,7 @@ export const showSpellsForClassAndLevel = async (
       return res.status(404).json({ error: 'Not found' });
     }
 
-    const urlString = '/api/classes/' + req.params.index;
+    const urlString = '/api/2014/classes/' + req.params.index;
 
     const data = await Spell.find({
       'classes.url': urlString,
@@ -161,7 +161,7 @@ export const showSpellsForClassAndLevel = async (
 
 export const showFeaturesForClass = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const urlString = '/api/classes/' + req.params.index;
+    const urlString = '/api/2014/classes/' + req.params.index;
 
     const data = await Feature.find({
       'class.url': urlString,
@@ -184,7 +184,7 @@ export const showFeaturesForClassAndLevel = async (
       return res.status(404).json({ error: 'Not found' });
     }
 
-    const urlString = '/api/classes/' + req.params.index;
+    const urlString = '/api/2014/classes/' + req.params.index;
 
     const data = await Feature.find({
       'class.url': urlString,
@@ -204,7 +204,7 @@ export const showProficienciesForClass = async (
   next: NextFunction
 ) => {
   try {
-    const urlString = '/api/classes/' + req.params.index;
+    const urlString = '/api/2014/classes/' + req.params.index;
 
     const data = await Proficiency.find({ 'classes.url': urlString })
       .select({ index: 1, name: 1, url: 1, _id: 0 })

--- a/src/controllers/api/2014/raceController.ts
+++ b/src/controllers/api/2014/raceController.ts
@@ -16,7 +16,7 @@ export const show = async (req: Request, res: Response, next: NextFunction) =>
 
 export const showSubracesForRace = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const urlString = '/api/races/' + req.params.index;
+    const urlString = '/api/2014/races/' + req.params.index;
 
     const data = await Subrace.find({ 'race.url': urlString }).select({
       index: 1,
@@ -32,7 +32,7 @@ export const showSubracesForRace = async (req: Request, res: Response, next: Nex
 
 export const showTraitsForRace = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const urlString = '/api/races/' + req.params.index;
+    const urlString = '/api/2014/races/' + req.params.index;
 
     const data = await Trait.find({ 'races.url': urlString }).select({
       index: 1,
@@ -48,7 +48,7 @@ export const showTraitsForRace = async (req: Request, res: Response, next: NextF
 
 export const showProficienciesForRace = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const urlString = '/api/races/' + req.params.index;
+    const urlString = '/api/2014/races/' + req.params.index;
 
     const data = await Proficiency.find({ 'races.url': urlString })
       .select({ index: 1, name: 1, url: 1, _id: 0 })

--- a/src/controllers/api/2014/subclassController.ts
+++ b/src/controllers/api/2014/subclassController.ts
@@ -14,7 +14,7 @@ export const show = async (req: Request, res: Response, next: NextFunction) =>
 
 export const showLevelsForSubclass = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const urlString = '/api/subclasses/' + req.params.index;
+    const urlString = '/api/2014/subclasses/' + req.params.index;
 
     const data = await Level.find({ 'subclass.url': urlString }).sort({ level: 'asc' });
     return res.status(200).json(data);
@@ -29,7 +29,7 @@ export const showLevelForSubclass = async (req: Request, res: Response, next: Ne
       return res.status(404).json({ error: 'Not found' });
     }
 
-    const urlString = '/api/subclasses/' + req.params.index + '/levels/' + req.params.level;
+    const urlString = '/api/2014/subclasses/' + req.params.index + '/levels/' + req.params.level;
 
     const data = await Level.findOne({ url: urlString });
     if (!data) return next();
@@ -41,7 +41,7 @@ export const showLevelForSubclass = async (req: Request, res: Response, next: Ne
 
 export const showFeaturesForSubclass = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const urlString = '/api/subclasses/' + req.params.index;
+    const urlString = '/api/2014/subclasses/' + req.params.index;
 
     const data = await Feature.find({
       'subclass.url': urlString,
@@ -64,7 +64,7 @@ export const showFeaturesForSubclassAndLevel = async (
       return res.status(404).json({ error: 'Not found' });
     }
 
-    const urlString = '/api/subclasses/' + req.params.index;
+    const urlString = '/api/2014/subclasses/' + req.params.index;
 
     const data = await Feature.find({
       level: parseInt(req.params.level),

--- a/src/controllers/api/2014/subraceController.ts
+++ b/src/controllers/api/2014/subraceController.ts
@@ -14,7 +14,7 @@ export const show = async (req: Request, res: Response, next: NextFunction) =>
 
 export const showTraitsForSubrace = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const urlString = '/api/subraces/' + req.params.index;
+    const urlString = '/api/2014/subraces/' + req.params.index;
     const data = await Trait.find({ 'subraces.url': urlString }).select({
       index: 1,
       name: 1,
@@ -34,7 +34,7 @@ export const showProficienciesForSubrace = async (
   next: NextFunction
 ) => {
   try {
-    const urlString = '/api/subraces/' + req.params.index;
+    const urlString = '/api/2014/subraces/' + req.params.index;
 
     const data = await Proficiency.find({ 'races.url': urlString })
       .select({ index: 1, name: 1, url: 1, _id: 0 })

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -66,7 +66,7 @@
             <div class="interactive-section">
                 <h1>Try it now!</h1>
                 <div class="api-input">
-                    <span class="api-prefix">https://www.dnd5eapi.co/api/</span>
+                    <span class="api-prefix">https://www.dnd5eapi.co/api/2014/</span>
                     <input id="interactive" type="text" placeholder="spells/acid-arrow/" />
                     <button onclick="interactiveCall();return false;">
                         submit

--- a/src/util/prewarmCache.ts
+++ b/src/util/prewarmCache.ts
@@ -16,23 +16,23 @@ const prewarmCache = async () => {
   const toPrewarm: PrewarmData[] = [
     {
       Schema: MagicItem,
-      endpoint: '/api/magic-items',
+      endpoint: '/api/2014/magic-items',
     },
     {
       Schema: Spell,
-      endpoint: '/api/spells',
+      endpoint: '/api/2014/spells',
     },
     {
       Schema: Monster,
-      endpoint: '/api/monsters',
+      endpoint: '/api/2014/monsters',
     },
     {
       Schema: Rule,
-      endpoint: '/api/rules',
+      endpoint: '/api/2014/rules',
     },
     {
       Schema: RuleSection,
-      endpoint: '/api/rule-sections',
+      endpoint: '/api/2014/rule-sections',
     },
   ];
   for (const element of toPrewarm) {


### PR DESCRIPTION
## What does this do?
Updates various paths throughout the 2014 controllers, cache prewarming, the README and the website, to use the new versioned `/api/2014` endpoint.

## How was it tested?
Visiting the affected endpoints in a local docker build.

## Is there a Github issue this is resolving?
No

## Was any impacted documentation updated to reflect this change?
N/A

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
