### PR TITLE
feat: add terrain_type_options and enemy_type_options to feature schema

### DIFF
--- a/src/graphql/2014/resolvers/featureResolver.ts
+++ b/src/graphql/2014/resolvers/featureResolver.ts
@@ -34,6 +34,30 @@ type FeatureSpecific = {
       }[];
     };
   };
+  terrain_type_options?: {
+    desc?: string;
+    choose: number;
+    type: string;
+    from: {
+      option_set_type: 'options_array';
+      options: {
+        option_type: 'string';
+        string: string;
+      }[];
+    };
+  };
+  enemy_type_options?: {
+    desc?: string;
+    choose: number;
+    type: string;
+    from: {
+      option_set_type: 'options_array';
+      options: {
+        option_type: 'string';
+        string: string;
+      }[];
+    };
+  };
   invocations?: Feature[];
 };
 
@@ -133,6 +157,30 @@ const Feature = {
           options: feature_specific.expertise_options.from.options.map(
             async (option) => await resolveExpertiseOption(option)
           ),
+        }
+      );
+    }
+
+    if (
+      feature_specific.terrain_type_options &&
+      'options' in feature_specific.terrain_type_options.from
+    ) {
+      featureSpecificToReturn.terrain_type_options = resolveChoice(
+        feature_specific.terrain_type_options,
+        {
+          options: feature_specific.terrain_type_options.from.options,
+        }
+      );
+    }
+
+    if (
+      feature_specific.enemy_type_options &&
+      'options' in feature_specific.enemy_type_options.from
+    ) {
+      featureSpecificToReturn.enemy_type_options = resolveChoice(
+        feature_specific.enemy_type_options,
+        {
+          options: feature_specific.enemy_type_options.from.options,
         }
       );
     }

--- a/src/graphql/2014/typeDefs.graphql
+++ b/src/graphql/2014/typeDefs.graphql
@@ -1081,6 +1081,8 @@ type ExpertiseChoice {
 type FeatureSpecific {
   expertise_options: ExpertiseChoice
   subfeature_options: FeatureChoice
+  terrain_type_options: StringChoice
+  enemy_type_options: StringChoice
   invocations: [Feature!]
 }
 

--- a/src/models/2014/feature/index.ts
+++ b/src/models/2014/feature/index.ts
@@ -32,6 +32,8 @@ const FeatureSpecificSchema = new Schema<FeatureSpecific>({
   _id: false,
   subfeature_options: ChoiceSchema,
   expertise_options: ChoiceSchema,
+  terrain_type_options: ChoiceSchema,
+  enemy_type_options: ChoiceSchema,
   invocations: [APIReferenceSchema],
 });
 

--- a/src/models/2014/feature/types.d.ts
+++ b/src/models/2014/feature/types.d.ts
@@ -25,6 +25,8 @@ type FeatureSpecific = {
   _id?: boolean;
   subfeature_options?: Choice;
   expertise_options?: Choice;
+  terrain_type_options?: Choice;
+  enemy_type_options?: Choice;
   invocations?: APIReference[];
 };
 

--- a/src/swagger/schemas/2014/features.yml
+++ b/src/swagger/schemas/2014/features.yml
@@ -46,4 +46,18 @@ allOf:
             spell: "shield"
       feature_specific:
         description: "Information specific to this feature."
+        type: object
+        properties:
+          subfeature_options:
+            $ref: "./combined.yml#/Choice"
+          expertise_options:
+            $ref: "./combined.yml#/Choice"
+          terrain_type_options:
+            $ref: "./combined.yml#/Choice"
+          enemy_type_options:
+            $ref: "./combined.yml#/Choice"
+          invocations:
+            type: array
+            items:
+              $ref: "./combined.yml#/APIReference"
         additionalProperties: true


### PR DESCRIPTION
- Added new fields to Feature types and schemas for Rangers' Natural Explorer and Favored Enemy choices
- Updated Mongoose schema, TypeScript types, OpenAPI schema, and GraphQL schema/resolvers
- Supports PRs #794 and #795 from the 5e-bits/5e-database repository