### PR TITLE
fix(models): Remove _id and id fields from response

### DIFF
--- a/src/models/2014/abilityScore.ts
+++ b/src/models/2014/abilityScore.ts
@@ -1,7 +1,9 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference } from './common';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-ability-scores')
 export class AbilityScore {
   @prop({ required: true, index: true })
   public desc!: string[];
@@ -26,8 +28,6 @@ export class AbilityScore {
 }
 
 export type AbilityScoreDocument = DocumentType<AbilityScore>;
-const AbilityScoreModel = getModelForClass(AbilityScore, {
-  schemaOptions: { collection: '2014-ability-scores' },
-});
+const AbilityScoreModel = getModelForClass(AbilityScore);
 
 export default AbilityScoreModel;

--- a/src/models/2014/alignment.ts
+++ b/src/models/2014/alignment.ts
@@ -1,6 +1,8 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-alignments')
 export class Alignment {
   @prop({ required: true, index: true })
   public desc!: string[];
@@ -22,8 +24,6 @@ export class Alignment {
 }
 
 export type AlignmentDocument = DocumentType<Alignment>;
-const AlignmentModel = getModelForClass(Alignment, {
-  schemaOptions: { collection: '2014-alignments' },
-});
+const AlignmentModel = getModelForClass(Alignment);
 
 export default AlignmentModel;

--- a/src/models/2014/background.ts
+++ b/src/models/2014/background.ts
@@ -1,6 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference, Choice } from './common';
+import { srdModelOptions } from '@/util/modelOptions';
 
 export class EquipmentRef {
   @prop({ type: () => APIReference })
@@ -18,6 +19,7 @@ class Feature {
   public desc!: string[];
 }
 
+@srdModelOptions('2014-backgrounds')
 export class Background {
   @prop({ required: true, index: true })
   public index!: string;
@@ -60,8 +62,6 @@ export class Background {
 }
 
 export type BackgroundDocument = DocumentType<Background>;
-const BackgroundModel = getModelForClass(Background, {
-  schemaOptions: { collection: '2014-backgrounds' },
-});
+const BackgroundModel = getModelForClass(Background);
 
 export default BackgroundModel;

--- a/src/models/2014/class.ts
+++ b/src/models/2014/class.ts
@@ -1,6 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference, Choice } from './common';
+import { srdModelOptions } from '@/util/modelOptions';
 
 class Equipment {
   @prop({ type: () => APIReference })
@@ -51,6 +52,7 @@ class MultiClassing {
   public proficiency_choices?: Choice[];
 }
 
+@srdModelOptions('2014-classes')
 class Class {
   @prop({ required: true, index: true })
   public class_levels!: string;
@@ -99,7 +101,5 @@ class Class {
 }
 
 export type ClassDocument = DocumentType<Class>;
-const ClassModel = getModelForClass(Class, {
-  schemaOptions: { collection: '2014-classes' },
-});
+const ClassModel = getModelForClass(Class);
 export default ClassModel;

--- a/src/models/2014/collection.ts
+++ b/src/models/2014/collection.ts
@@ -1,14 +1,14 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-collections')
 export class Collection {
   @prop({ required: true, index: true })
   public index!: string;
 }
 
 export type CollectionDocument = DocumentType<Collection>;
-const CollectionModel = getModelForClass(Collection, {
-  schemaOptions: { collection: '2014-collections' },
-});
+const CollectionModel = getModelForClass(Collection);
 
 export default CollectionModel;

--- a/src/models/2014/condition.ts
+++ b/src/models/2014/condition.ts
@@ -1,6 +1,8 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-conditions')
 export class Condition {
   @prop({ required: true, index: true })
   public desc!: string[];
@@ -19,8 +21,6 @@ export class Condition {
 }
 
 export type ConditionDocument = DocumentType<Condition>;
-const ConditionModel = getModelForClass(Condition, {
-  schemaOptions: { collection: '2014-conditions' },
-});
+const ConditionModel = getModelForClass(Condition);
 
 export default ConditionModel;

--- a/src/models/2014/damageType.ts
+++ b/src/models/2014/damageType.ts
@@ -1,6 +1,8 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-damage-types')
 export class DamageType {
   @prop({ required: true, index: true })
   public desc!: string[];
@@ -19,8 +21,6 @@ export class DamageType {
 }
 
 export type DamageTypeDocument = DocumentType<DamageType>;
-const DamageTypeModel = getModelForClass(DamageType, {
-  schemaOptions: { collection: '2014-damage-types' },
-});
+const DamageTypeModel = getModelForClass(DamageType);
 
 export default DamageTypeModel;

--- a/src/models/2014/equipment.ts
+++ b/src/models/2014/equipment.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference } from '@/models/2014/common';
-
+import { srdModelOptions } from '@/util/modelOptions';
 class ArmorClass {
   @prop({ required: true, index: true })
   public base!: number;
@@ -69,6 +69,7 @@ class TwoHandedDamage {
   public damage_type!: APIReference;
 }
 
+@srdModelOptions('2014-equipment')
 export class Equipment {
   @prop({ index: true })
   public armor_category?: string;
@@ -156,8 +157,6 @@ export class Equipment {
 }
 
 export type EquipmentDocument = DocumentType<Equipment>;
-const EquipmentModel = getModelForClass(Equipment, {
-  schemaOptions: { collection: '2014-equipment' },
-});
+const EquipmentModel = getModelForClass(Equipment);
 
 export default EquipmentModel;

--- a/src/models/2014/equipmentCategory.ts
+++ b/src/models/2014/equipmentCategory.ts
@@ -1,7 +1,9 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference } from '@/models/2014/common';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-equipment-categories')
 export class EquipmentCategory {
   @prop({ type: () => [APIReference], index: true })
   public equipment!: APIReference[];
@@ -20,8 +22,6 @@ export class EquipmentCategory {
 }
 
 export type EquipmentCategoryDocument = DocumentType<EquipmentCategory>;
-const EquipmentCategoryModel = getModelForClass(EquipmentCategory, {
-  schemaOptions: { collection: '2014-equipment-categories' },
-});
+const EquipmentCategoryModel = getModelForClass(EquipmentCategory);
 
 export default EquipmentCategoryModel;

--- a/src/models/2014/feat.ts
+++ b/src/models/2014/feat.ts
@@ -1,6 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference } from '@/models/2014/common';
+import { srdModelOptions } from '@/util/modelOptions';
 
 export class Prerequisite {
   @prop({ type: () => APIReference })
@@ -10,6 +11,7 @@ export class Prerequisite {
   public minimum_score!: number;
 }
 
+@srdModelOptions('2014-feats')
 export class Feat {
   @prop({ required: true, index: true })
   public index!: string;
@@ -31,8 +33,6 @@ export class Feat {
 }
 
 export type FeatDocument = DocumentType<Feat>;
-const FeatModel = getModelForClass(Feat, {
-  schemaOptions: { collection: '2014-feats' },
-});
+const FeatModel = getModelForClass(Feat);
 
 export default FeatModel;

--- a/src/models/2014/feature.ts
+++ b/src/models/2014/feature.ts
@@ -1,6 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference, Choice } from '@/models/2014/common';
+import { srdModelOptions } from '@/util/modelOptions';
 
 class LevelPrerequisite {
   @prop({ required: true, index: true })
@@ -43,6 +44,7 @@ class FeatureSpecific {
   public invocations?: APIReference[];
 }
 
+@srdModelOptions('2014-features')
 export class Feature {
   @prop({ type: () => APIReference })
   public class!: APIReference;
@@ -82,8 +84,6 @@ export class Feature {
 }
 
 export type FeatureDocument = DocumentType<Feature>;
-const FeatureModel = getModelForClass(Feature, {
-  schemaOptions: { collection: '2014-features' },
-});
+const FeatureModel = getModelForClass(Feature);
 
 export default FeatureModel;

--- a/src/models/2014/language.ts
+++ b/src/models/2014/language.ts
@@ -1,6 +1,8 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-languages')
 export class Language {
   @prop({ required: true, index: true })
   public desc!: string[];
@@ -28,8 +30,6 @@ export class Language {
 }
 
 export type LanguageDocument = DocumentType<Language>;
-const LanguageModel = getModelForClass(Language, {
-  schemaOptions: { collection: '2014-languages' },
-});
+const LanguageModel = getModelForClass(Language);
 
 export default LanguageModel;

--- a/src/models/2014/level.ts
+++ b/src/models/2014/level.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference } from '@/models/2014/common';
-
+import { srdModelOptions } from '@/util/modelOptions';
 class ClassSpecificCreatingSpellSlot {
   @prop({ required: true, index: true })
   public sorcery_point_cost!: number;
@@ -167,6 +167,7 @@ export class SubclassSpecific {
   public aura_range?: number;
 }
 
+@srdModelOptions('2014-levels')
 export class Level {
   @prop({ index: true })
   public ability_score_bonuses?: number;
@@ -206,8 +207,6 @@ export class Level {
 }
 
 export type LevelDocument = DocumentType<Level>;
-const LevelModel = getModelForClass(Level, {
-  schemaOptions: { collection: '2014-levels' },
-});
+const LevelModel = getModelForClass(Level);
 
 export default LevelModel;

--- a/src/models/2014/magicItem.ts
+++ b/src/models/2014/magicItem.ts
@@ -1,12 +1,13 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference } from './common';
-
+import { srdModelOptions } from '@/util/modelOptions';
 class Rarity {
   @prop({ required: true, index: true })
   public name!: string;
 }
 
+@srdModelOptions('2014-magic-items')
 export class MagicItem {
   @prop({ type: () => [String], index: true })
   public desc!: string[];
@@ -40,8 +41,6 @@ export class MagicItem {
 }
 
 export type MagicItemDocument = DocumentType<MagicItem>;
-const MagicItemModel = getModelForClass(MagicItem, {
-  schemaOptions: { collection: '2014-magic-items' },
-});
+const MagicItemModel = getModelForClass(MagicItem);
 
 export default MagicItemModel;

--- a/src/models/2014/magicSchool.ts
+++ b/src/models/2014/magicSchool.ts
@@ -1,6 +1,8 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-magic-schools')
 export class MagicSchool {
   @prop({ type: () => [String], index: true })
   public desc!: string[];
@@ -19,8 +21,6 @@ export class MagicSchool {
 }
 
 export type MagicSchoolDocument = DocumentType<MagicSchool>;
-const MagicSchoolModel = getModelForClass(MagicSchool, {
-  schemaOptions: { collection: '2014-magic-schools' },
-});
+const MagicSchoolModel = getModelForClass(MagicSchool);
 
 export default MagicSchoolModel;

--- a/src/models/2014/monster.ts
+++ b/src/models/2014/monster.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference, Choice, DifficultyClass, Damage } from './common';
-
+import { srdModelOptions } from '@/util/modelOptions';
 class ActionOption {
   @prop({ required: true, index: true })
   public action_name!: string;
@@ -270,6 +270,7 @@ class Speed {
   public walk?: string;
 }
 
+@srdModelOptions('2014-monsters')
 export class Monster {
   @prop({ type: () => [Action] })
   public actions?: Action[];
@@ -381,8 +382,6 @@ export class Monster {
 }
 
 export type MonsterDocument = DocumentType<Monster>;
-const MonsterModel = getModelForClass(Monster, {
-  schemaOptions: { collection: '2014-monsters' },
-});
+const MonsterModel = getModelForClass(Monster);
 
 export default MonsterModel;

--- a/src/models/2014/proficiency.ts
+++ b/src/models/2014/proficiency.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference } from '@/models/2014/common';
-
+import { srdModelOptions } from '@/util/modelOptions';
 class Reference {
   @prop({ required: true, index: true })
   public index!: string;
@@ -16,6 +16,7 @@ class Reference {
   public url!: string;
 }
 
+@srdModelOptions('2014-proficiencies')
 export class Proficiency {
   @prop({ type: () => [APIReference] })
   public classes?: APIReference[];
@@ -43,8 +44,6 @@ export class Proficiency {
 }
 
 export type ProficiencyDocument = DocumentType<Proficiency>;
-const ProficiencyModel = getModelForClass(Proficiency, {
-  schemaOptions: { collection: '2014-proficiencies' },
-});
+const ProficiencyModel = getModelForClass(Proficiency);
 
 export default ProficiencyModel;

--- a/src/models/2014/race.ts
+++ b/src/models/2014/race.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference, Choice } from '@/models/2014/common';
-
+import { srdModelOptions } from '@/util/modelOptions';
 class RaceAbilityBonus {
   @prop({ type: () => APIReference, required: true })
   public ability_score!: APIReference;
@@ -10,6 +10,7 @@ class RaceAbilityBonus {
   public bonus!: number;
 }
 
+@srdModelOptions('2014-races')
 export class Race {
   @prop({ type: () => Choice })
   public ability_bonus_options?: Choice;
@@ -67,8 +68,6 @@ export class Race {
 }
 
 export type RaceDocument = DocumentType<Race>;
-const RaceModel = getModelForClass(Race, {
-  schemaOptions: { collection: '2014-races' },
-});
+const RaceModel = getModelForClass(Race);
 
 export default RaceModel;

--- a/src/models/2014/rule.ts
+++ b/src/models/2014/rule.ts
@@ -1,7 +1,9 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference } from '@/models/2014/common';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-rules')
 export class Rule {
   @prop({ required: true, index: true })
   public desc!: string;
@@ -23,8 +25,6 @@ export class Rule {
 }
 
 export type RuleDocument = DocumentType<Rule>;
-const RuleModel = getModelForClass(Rule, {
-  schemaOptions: { collection: '2014-rules' },
-});
+const RuleModel = getModelForClass(Rule);
 
 export default RuleModel;

--- a/src/models/2014/ruleSection.ts
+++ b/src/models/2014/ruleSection.ts
@@ -1,6 +1,8 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-rule-sections')
 export class RuleSection {
   @prop({ required: true, index: true })
   public desc!: string;
@@ -19,8 +21,6 @@ export class RuleSection {
 }
 
 export type RuleSectionDocument = DocumentType<RuleSection>;
-const RuleSectionModel = getModelForClass(RuleSection, {
-  schemaOptions: { collection: '2014-rule-sections' },
-});
+const RuleSectionModel = getModelForClass(RuleSection);
 
 export default RuleSectionModel;

--- a/src/models/2014/skill.ts
+++ b/src/models/2014/skill.ts
@@ -1,7 +1,9 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference } from '@/models/2014/common';
+import { srdModelOptions } from '@/util/modelOptions';
 
+@srdModelOptions('2014-skills')
 export class Skill {
   @prop({ type: () => APIReference })
   public ability_score!: APIReference;
@@ -23,8 +25,6 @@ export class Skill {
 }
 
 export type SkillDocument = DocumentType<Skill>;
-const SkillModel = getModelForClass(Skill, {
-  schemaOptions: { collection: '2014-skills' },
-});
+const SkillModel = getModelForClass(Skill);
 
 export default SkillModel;

--- a/src/models/2014/spell.ts
+++ b/src/models/2014/spell.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference, AreaOfEffect } from '@/models/2014/common';
-
+import { srdModelOptions } from '@/util/modelOptions';
 class Damage {
   @prop({ type: Object })
   public damage_at_slot_level?: Record<number, string>;
@@ -24,6 +24,7 @@ class DC {
   public desc?: string;
 }
 
+@srdModelOptions('2014-spells')
 export class Spell {
   @prop({ type: () => AreaOfEffect })
   public area_of_effect?: AreaOfEffect;
@@ -93,8 +94,6 @@ export class Spell {
 }
 
 export type SpellDocument = DocumentType<Spell>;
-const SpellModel = getModelForClass(Spell, {
-  schemaOptions: { collection: '2014-spells' },
-});
+const SpellModel = getModelForClass(Spell);
 
 export default SpellModel;

--- a/src/models/2014/subclass.ts
+++ b/src/models/2014/subclass.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference } from '@/models/2014/common';
-
+import { srdModelOptions } from '@/util/modelOptions';
 class SpellPrerequisite {
   @prop({ required: true, index: true })
   public index!: string;
@@ -24,6 +24,7 @@ class Spell {
   public spell!: APIReference;
 }
 
+@srdModelOptions('2014-subclasses')
 export class Subclass {
   @prop({ type: () => APIReference })
   public class!: APIReference;
@@ -54,8 +55,6 @@ export class Subclass {
 }
 
 export type SubclassDocument = DocumentType<Subclass>;
-const SubclassModel = getModelForClass(Subclass, {
-  schemaOptions: { collection: '2014-subclasses' },
-});
+const SubclassModel = getModelForClass(Subclass);
 
 export default SubclassModel;

--- a/src/models/2014/subrace.ts
+++ b/src/models/2014/subrace.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference, Choice } from '@/models/2014/common';
-
+import { srdModelOptions } from '@/util/modelOptions';
 class AbilityBonus {
   @prop({ type: () => APIReference })
   public ability_score!: APIReference;
@@ -10,6 +10,7 @@ class AbilityBonus {
   public bonus!: number;
 }
 
+@srdModelOptions('2014-subraces')
 export class Subrace {
   @prop({ type: () => [AbilityBonus] })
   public ability_bonuses!: AbilityBonus[];
@@ -43,8 +44,6 @@ export class Subrace {
 }
 
 export type SubraceDocument = DocumentType<Subrace>;
-const SubraceModel = getModelForClass(Subrace, {
-  schemaOptions: { collection: '2014-subraces' },
-});
+const SubraceModel = getModelForClass(Subrace);
 
 export default SubraceModel;

--- a/src/models/2014/trait.ts
+++ b/src/models/2014/trait.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
 import { APIReference, Choice, AreaOfEffect, DifficultyClass } from './common';
-
+import { srdModelOptions } from '@/util/modelOptions';
 class Proficiency {
   @prop({ required: true, index: true })
   public index!: string;
@@ -63,6 +63,7 @@ class TraitSpecific {
   public breath_weapon?: Action;
 }
 
+@srdModelOptions('2014-traits')
 export class Trait {
   @prop({ type: () => [String], required: true, index: true })
   public desc!: string[];
@@ -102,8 +103,6 @@ export class Trait {
 }
 
 export type TraitDocument = DocumentType<Trait>;
-const TraitModel = getModelForClass(Trait, {
-  schemaOptions: { collection: '2014-traits' },
-});
+const TraitModel = getModelForClass(Trait);
 
 export default TraitModel;

--- a/src/models/2014/weaponProperty.ts
+++ b/src/models/2014/weaponProperty.ts
@@ -1,6 +1,7 @@
 import { getModelForClass, prop } from '@typegoose/typegoose';
 import { DocumentType } from '@typegoose/typegoose/lib/types';
-
+import { srdModelOptions } from '@/util/modelOptions';
+@srdModelOptions('2014-weapon-properties')
 export class WeaponProperty {
   @prop({ required: true, index: true })
   public desc!: string[];
@@ -19,8 +20,6 @@ export class WeaponProperty {
 }
 
 export type WeaponPropertyDocument = DocumentType<WeaponProperty>;
-const WeaponPropertyModel = getModelForClass(WeaponProperty, {
-  schemaOptions: { collection: '2014-weapon-properties' },
-});
+const WeaponPropertyModel = getModelForClass(WeaponProperty);
 
 export default WeaponPropertyModel;

--- a/src/tests/util/data.test.ts
+++ b/src/tests/util/data.test.ts
@@ -1,71 +1,11 @@
-import { ClassAPIResource, ResourceList } from '@/util/data';
-
-describe('ClassAPIResource', () => {
-  it('returns a constructed hash from list', () => {
-    const data = [
-      {
-        index: 'test1',
-        class: {
-          name: 'Test 1',
-        },
-        url: '/made/up/url/test1',
-      },
-      {
-        index: 'test2',
-        class: {
-          name: 'Test 2',
-        },
-        url: '/made/up/url/test2',
-      },
-      {
-        index: 'test2',
-        class: {
-          name: 'Test 2',
-        },
-        url: '/made/up/url/test2',
-      },
-    ];
-    const expectedData = [
-      {
-        index: 'test1',
-        class: 'Test 1',
-        url: '/made/up/url/test1',
-      },
-      {
-        index: 'test2',
-        class: 'Test 2',
-        url: '/made/up/url/test2',
-      },
-      {
-        index: 'test2',
-        class: 'Test 2',
-        url: '/made/up/url/test2',
-      },
-    ];
-    const resource = ClassAPIResource(data);
-    expect(resource.count).toEqual(data.length);
-    expect(resource.results).toEqual(expectedData);
-  });
-});
+import { ResourceList } from '@/util/data';
 
 describe('ResourceList', () => {
   it('returns a constructed hash from list', () => {
     const data = [
-      {
-        index: 'test1',
-        name: 'Test 1',
-        url: '/made/up/url/test1',
-      },
-      {
-        index: 'test2',
-        name: 'Test 2',
-        url: '/made/up/url/test2',
-      },
-      {
-        index: 'test2',
-        name: 'Test 2',
-        url: '/made/up/url/test2',
-      },
+      { index: 'test1', name: 'Test 1', url: '/made/up/url/test1' },
+      { index: 'test2', name: 'Test 2', url: '/made/up/url/test2' },
+      { index: 'test2', name: 'Test 2', url: '/made/up/url/test2' },
     ];
     const resource = ResourceList(data);
     expect(resource.count).toEqual(data.length);

--- a/src/util/data.ts
+++ b/src/util/data.ts
@@ -1,28 +1,3 @@
-type ClassAPIData = {
-  index: string;
-  url: string;
-  class: {
-    name: string;
-  };
-}[];
-export const ClassAPIResource = (data: ClassAPIData) => {
-  const mapped = data.map(item => {
-    return {
-      index: item.index,
-      class: item.class.name,
-      url: item.url,
-    };
-  });
-
-  return {
-    count: data.length,
-    results: mapped,
-  };
-};
-
 export const ResourceList = (data: any[]) => {
-  return {
-    count: data.length,
-    results: data,
-  };
+  return { count: data.length, results: data };
 };

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,4 +1,4 @@
-import { ClassAPIResource, ResourceList } from './data';
+import { ResourceList } from './data';
 import { bugsnagApiKey, mongodbUri } from './environmentVariables';
 
 import { escapeRegExp } from './regex';
@@ -13,6 +13,5 @@ export {
   prewarmCache,
   escapeRegExp,
   ResourceList,
-  ClassAPIResource,
   awsS3Client,
 };

--- a/src/util/modelOptions.ts
+++ b/src/util/modelOptions.ts
@@ -1,0 +1,62 @@
+import { modelOptions, Severity } from '@typegoose/typegoose';
+
+/**
+ * Helper function to recursively remove _id and __v fields.
+ * @param obj The object or array to process.
+ */
+function removeInternalFields(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj.map(removeInternalFields);
+  } else if (obj !== null && typeof obj === 'object') {
+    // Mongoose documents might have a toObject method, use it if available
+    const plainObject = typeof obj.toObject === 'function' ? obj.toObject() : obj;
+
+    // Create a new object to avoid modifying the original Mongoose document directly if necessary
+    const newObj: any = {};
+    for (const key in plainObject) {
+      if (key !== '_id' && key !== '__v' && key !== 'id') {
+        newObj[key] = removeInternalFields(plainObject[key]);
+      }
+    }
+    return newObj;
+  }
+  return obj; // Return primitives/unhandled types as is
+}
+
+/**
+ * Creates common Typegoose model options for SRD API models.
+ * - Sets the collection name.
+ * - Disables the default _id field.
+ * - Enables timestamps (createdAt, updatedAt).
+ * - Configures toJSON and toObject transforms to remove _id and __v recursively.
+ *
+ * @param collectionName The name of the MongoDB collection.
+ * @returns A Typegoose ClassDecorator.
+ */
+export function srdModelOptions(collectionName: string): ClassDecorator {
+  return modelOptions({
+    // It's often good practice to explicitly set allowMixed
+    options: { allowMixed: Severity.ALLOW },
+    schemaOptions: {
+      collection: collectionName,
+      // Prevent Mongoose from managing the _id field directly
+      _id: false,
+      // Automatically add createdAt and updatedAt timestamps
+      timestamps: true,
+      // Modify the object when converting to JSON (e.g., for API responses)
+      toJSON: {
+        virtuals: true, // Ensure virtuals are included if you add any
+        transform: (doc, ret) => {
+          return removeInternalFields(ret);
+        },
+      },
+      // Also apply the same transform when converting to a plain object
+      toObject: {
+        virtuals: true,
+        transform: (doc, ret) => {
+          return removeInternalFields(ret);
+        },
+      },
+    },
+  });
+}


### PR DESCRIPTION
## What does this do?

* Updates model files to once again no longer show `_id` of `id` fields
  * This is done by adding a new decorator called `srdModelOptions` which both scrubs the data and also sets the collection name.
* Removes `ClassAPIResource` which is no longer used

## How was it tested?

By spinning up the server and hitting some of the API endpoints

## Is there a Github issue this is resolving?

[Raised in #help in discord](https://discord.com/channels/656547667601653787/664902912014680068/1360462933288816832)
