### PR TITLE
docs(PR): Swap image link to text so people actually add images

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@
 \<It's not clear if I don't update this text with relevant info\>
 
 ## Here's a fun image for your troubles
-![random photo - update me](https://picsum.photos/200)
+\<Add a fun image here\>


### PR DESCRIPTION
## What does this do?

Swaps PR template from image to text so people actually add images.

## How was it tested?

In other repos.

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/c782007d-ad33-4bc1-8f0d-27af56f27cae)

