### PR TITLE
fix(models): No more Mixed warnings from Typegoose

### DIFF
--- a/src/models/2014/monster.ts
+++ b/src/models/2014/monster.ts
@@ -1,4 +1,4 @@
-import { getModelForClass, prop } from '@typegoose/typegoose'
+import { getModelForClass, modelOptions, prop, Severity } from '@typegoose/typegoose'
 import { DocumentType } from '@typegoose/typegoose/lib/types'
 import { APIReference, Choice, DifficultyClass, Damage } from './common'
 import { srdModelOptions } from '@/util/modelOptions'
@@ -210,6 +210,7 @@ export class SpecialAbilitySpell {
   public usage?: SpecialAbilityUsage
 }
 
+@modelOptions({ options: { allowMixed: Severity.ALLOW } })
 export class SpecialAbilitySpellcasting {
   @prop({ index: true, type: () => Number })
   public level?: number

--- a/src/models/2014/spell.ts
+++ b/src/models/2014/spell.ts
@@ -1,8 +1,9 @@
-import { getModelForClass, prop } from '@typegoose/typegoose'
+import { getModelForClass, modelOptions, prop, Severity } from '@typegoose/typegoose'
 import { DocumentType } from '@typegoose/typegoose/lib/types'
 import { APIReference, AreaOfEffect } from '@/models/2014/common'
 import { srdModelOptions } from '@/util/modelOptions'
 
+@modelOptions({ options: { allowMixed: Severity.ALLOW } })
 export class SpellDamage {
   @prop({ type: () => APIReference })
   public damage_type?: APIReference

--- a/src/models/2014/trait.ts
+++ b/src/models/2014/trait.ts
@@ -1,4 +1,4 @@
-import { getModelForClass, prop } from '@typegoose/typegoose'
+import { getModelForClass, modelOptions, prop, Severity } from '@typegoose/typegoose'
 import { DocumentType } from '@typegoose/typegoose/lib/types'
 import { APIReference, Choice, AreaOfEffect, DifficultyClass } from '@/models/2014/common'
 import { srdModelOptions } from '@/util/modelOptions'
@@ -14,6 +14,7 @@ class Proficiency {
   public url!: string
 }
 
+@modelOptions({ options: { allowMixed: Severity.ALLOW } })
 class ActionDamage {
   @prop({ type: () => APIReference })
   public damage_type!: APIReference


### PR DESCRIPTION
## What does this do?

Quiets all the Mixed warnings from Typegoose that have been showing up during startup and testing.

## How was it tested?

I ran the integration tests and spun up the server

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/a5e391e6-9dd9-4c92-8859-7f78bb2abff8)
