### PR TITLE
feat(equipment): Add image to 2014 equipment model

### DIFF
--- a/src/models/2014/equipment.ts
+++ b/src/models/2014/equipment.ts
@@ -103,6 +103,9 @@ export class Equipment {
   @prop({ type: () => APIReference })
   public gear_category?: APIReference
 
+  @prop({ index: true, type: () => String })
+  public image?: string
+
   @prop({ required: true, index: true, type: () => String })
   public index!: string
 

--- a/src/models/2014/magicItem.ts
+++ b/src/models/2014/magicItem.ts
@@ -17,7 +17,7 @@ export class MagicItem {
   public equipment_category!: APIReference
 
   @prop({ type: () => String, index: true })
-  public image!: string
+  public image?: string
 
   @prop({ required: true, index: true, type: () => String })
   public index!: string

--- a/src/swagger/schemas/2014/equipment.yml
+++ b/src/swagger/schemas/2014/equipment.yml
@@ -13,6 +13,9 @@ equipment-category-model:
     - $ref: './combined.yml#/APIReference'
     - type: object
       properties:
+        image:
+          description: 'The image url of the magic item.'
+          type: string
         equipment:
           description: 'A list of the equipment that falls into this category.'
           type: array
@@ -26,6 +29,9 @@ gear-model:
     - $ref: './combined.yml#/ResourceDescription'
     - type: object
       properties:
+        image:
+          description: 'The image url of the gear.'
+          type: string
         equipment_category:
           $ref: './combined.yml#/APIReference'
         gear_category:
@@ -43,6 +49,9 @@ equipment-pack-model:
     - $ref: './combined.yml#/ResourceDescription'
     - type: object
       properties:
+        image:
+          description: 'The image url of the equipment pack.'
+          type: string
         equipment_category:
           $ref: './combined.yml#/APIReference'
         gear_category:

--- a/src/tests/factories/2014/equipment.factory.ts
+++ b/src/tests/factories/2014/equipment.factory.ts
@@ -61,7 +61,7 @@ const twoHandedDamageFactory = Factory.define<TwoHandedDamage>(() => ({
 }))
 
 // --- Main Equipment Factory ---
-export const equipmentFactory = Factory.define<Equipment>(({ sequence }) => {
+export const equipmentFactory = Factory.define<Equipment>(({ sequence, params }) => {
   const name = `Equipment ${sequence} - ${faker.commerce.productName()}`
   const index = name.toLowerCase().replace(/\s+/g, '-')
 
@@ -83,6 +83,7 @@ export const equipmentFactory = Factory.define<Equipment>(({ sequence }) => {
     contents: contentFactory.buildList(1),
     damage: damageFactory.build(),
     gear_category: undefined,
+    image: params.image ?? `/images/equipment/${index}.png`,
     properties: apiReferenceFactory.buildList(faker.number.int({ min: 0, max: 3 })),
     quantity: undefined,
     range: rangeFactory.build(),


### PR DESCRIPTION
## What does this do?

Exposes equipment image to API

## How was it tested?

CI

## Was any impacted documentation updated to reflect this change?

Yes

## Here's a fun image for your troubles

![crossbow-heavy](https://github.com/user-attachments/assets/a9cc6ea9-e6b2-469e-859f-ebfdf3dbcb6b)
