### PR TITLE
fix: :bug: Resolve full `Option` objects in `subrace.language_options` resolver

### DIFF
--- a/src/graphql/2014/resolvers/subraceResolver.ts
+++ b/src/graphql/2014/resolvers/subraceResolver.ts
@@ -56,9 +56,10 @@ const SubraceResolver = {
       const options = (subrace.language_options.from as OptionsArrayOptionSet).options.map(
         async (option: Option) => {
           if ('item' in option) {
-            return await LanguageModel.findOne({
+            const item = await LanguageModel.findOne({
               index: (option as ReferenceOption).item.index
             }).lean()
+            return { ...option, item }
           }
         }
       )


### PR DESCRIPTION
## What does this do?
Updates `SubraceResolver.language_options` to correctly resolve the options array. Previously, the options objects were replaced with the resolved `item`, replacing only the value of the `item` attribute.

### Before:
![image](https://github.com/user-attachments/assets/9a352258-30d4-4220-9c27-8d46d8898502)

### After:
![image](https://github.com/user-attachments/assets/d654d8a6-c2d4-41b6-b0b2-e8c545d8e2ad)

## How was it tested?
Locally, ad-hoc & ran unit tests.

## Is there a Github issue this is resolving?
No.

## Was any impacted documentation updated to reflect this change?
N/A

## Here's a fun image for your troubles
![u1jk9bfjav891](https://github.com/user-attachments/assets/452d92c2-432b-4dd3-b967-38631dd94e7a)

