### PR TITLE
fix(desc): Fix models to match data reality for desc

### DIFF
--- a/src/models/2014/alignment.ts
+++ b/src/models/2014/alignment.ts
@@ -4,8 +4,8 @@ import { srdModelOptions } from '@/util/modelOptions'
 
 @srdModelOptions('2014-alignments')
 export class Alignment {
-  @prop({ required: true, index: true, type: () => [String] })
-  public desc!: string[]
+  @prop({ required: true, index: true, type: () => String })
+  public desc!: string
 
   @prop({ required: true, index: true, type: () => String })
   public abbreviation!: string

--- a/src/models/2014/language.ts
+++ b/src/models/2014/language.ts
@@ -4,8 +4,8 @@ import { srdModelOptions } from '@/util/modelOptions'
 
 @srdModelOptions('2014-languages')
 export class Language {
-  @prop({ required: true, index: true, type: () => [String] })
-  public desc!: string[]
+  @prop({ required: true, index: true, type: () => String })
+  public desc!: string
 
   @prop({ required: true, index: true, type: () => String })
   public index!: string

--- a/src/models/2014/magicSchool.ts
+++ b/src/models/2014/magicSchool.ts
@@ -4,8 +4,8 @@ import { srdModelOptions } from '@/util/modelOptions'
 
 @srdModelOptions('2014-magic-schools')
 export class MagicSchool {
-  @prop({ type: () => [String], index: true })
-  public desc!: string[]
+  @prop({ type: () => String, index: true })
+  public desc!: string
 
   @prop({ required: true, index: true, type: () => String })
   public index!: string

--- a/src/models/2014/subrace.ts
+++ b/src/models/2014/subrace.ts
@@ -16,8 +16,8 @@ export class Subrace {
   @prop({ type: () => [SubraceAbilityBonus], required: true })
   public ability_bonuses!: SubraceAbilityBonus[]
 
-  @prop({ required: true, index: true, type: () => [String] })
-  public desc!: string[]
+  @prop({ required: true, index: true, type: () => String })
+  public desc!: string
 
   @prop({ required: true, index: true, type: () => String })
   public index!: string

--- a/src/tests/factories/2014/alignment.factory.ts
+++ b/src/tests/factories/2014/alignment.factory.ts
@@ -10,7 +10,7 @@ export const alignmentFactory = Factory.define<Alignment>(({ sequence, params })
     index,
     name,
     abbreviation: params.abbreviation ?? name.substring(0, 2).toUpperCase(), // Simple default
-    desc: params.desc ?? [faker.lorem.sentence()],
+    desc: params.desc ?? faker.lorem.sentence(),
     url: params.url ?? `/api/alignments/${index}`,
     updated_at: params.updated_at ?? faker.date.recent().toISOString(),
     ...params // Ensure overrides from params are applied

--- a/src/tests/factories/2014/language.factory.ts
+++ b/src/tests/factories/2014/language.factory.ts
@@ -15,7 +15,7 @@ export const languageFactory = Factory.define<Language>(({ sequence }) => {
   return {
     index: index,
     name: name,
-    desc: [faker.lorem.sentence()],
+    desc: faker.lorem.sentence(),
     script: faker.helpers.arrayElement(scripts),
     type: faker.helpers.arrayElement(languageTypes),
     typical_speakers: [faker.person.jobTitle(), faker.person.jobTitle()],

--- a/src/tests/factories/2014/magicSchool.factory.ts
+++ b/src/tests/factories/2014/magicSchool.factory.ts
@@ -12,7 +12,7 @@ export const magicSchoolFactory = Factory.define<MagicSchool>(({ sequence }) => 
   return {
     index: index,
     name: name,
-    desc: [faker.lorem.paragraph()],
+    desc: faker.lorem.paragraph(),
     url: `/api/magic-schools/${index}`,
     updated_at: faker.date.recent().toISOString()
   }

--- a/src/tests/factories/2014/subrace.factory.ts
+++ b/src/tests/factories/2014/subrace.factory.ts
@@ -21,7 +21,7 @@ export const subraceFactory = Factory.define<Subrace>(
       race:
         associations.race ??
         apiReferenceFactory.build({}, { transient: { resourceType: 'races' } }),
-      desc: [faker.lorem.paragraph()], // Ensure desc is an array of strings
+      desc: faker.lorem.paragraph(),
       ability_bonuses: subraceAbilityBonusFactory.buildList(faker.number.int({ min: 1, max: 2 })),
       starting_proficiencies:
         associations.starting_proficiencies ??


### PR DESCRIPTION
## What does this do?

When I migrated to Typegoose, I missed typed a few fields to be `String[]`. This fixes them to match the reality of the data.

## How was it tested?

CI

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/5a253aa9-f536-437e-869f-9fd78ea5ef4d)
