### PR TITLE
feat(class): Add `level` query for class spells for filtering spell level

### DIFF
--- a/src/swagger/paths/2014/classes.yml
+++ b/src/swagger/paths/2014/classes.yml
@@ -195,6 +195,7 @@ class-spells-path:
       - Class Resource Lists
     parameters:
       - $ref: '../../parameters/2014/combined.yml#/class-index'
+      - $ref: '../../parameters/2014/combined.yml#/level-filter'
     responses:
       '200':
         description: OK


### PR DESCRIPTION
## What does this do?

This PR introduces an optional level query parameter to the /api/2014/classes/{index}/spells endpoint, allowing clients to filter spells by one or more spell levels.
* `classController.ts`: Updated showSpellsForClass to parse and apply the level filter using SpellIndexQuerySchema for validation.
* `classController.test.ts`: Added comprehensive unit tests for the new level filtering capabilities, including various valid and invalid input scenarios.

## How was it tested?

Updated relevant unit tests

## Is there a Github issue this is resolving?

[Raised in Discord](https://discord.com/channels/656547667601653787/907534016440315934/1378083564737925344)

## Was any impacted documentation updated to reflect this change?

Updated the swagger doc as well.

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/5718c706-43d6-443d-a9f5-13c8f697421b)
