### PR TITLE
fix(graphql): Fix the endpoint for deprecated graphql endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -62,7 +62,15 @@ export default async () => {
   console.log('Setting up Apollo GraphQL server')
   const apolloMiddleware2014 = await createApolloMiddleware(schema)
   await apolloMiddleware2014.start()
-  app.all('/graphql', (_req, res) => res.redirect(301, '/graphql/2014'))
+  // DEPRECATED
+  app.use(
+    '/graphql',
+    cors<cors.CorsRequest>(),
+    bodyParser.json(),
+    expressMiddleware(apolloMiddleware2014, {
+      context: async ({ req }) => ({ token: req.headers.token })
+    })
+  )
   app.use(
     '/graphql/2014',
     cors<cors.CorsRequest>(),


### PR DESCRIPTION
## What does this do?

The redirect doesn't seem to be working anymore, so we're just going to hard code the endpoint for now until I rip it out.

## How was it tested?

Ran the server locally and pointed the sandbox at `/graphql`

## Is there a Github issue this is resolving?

Raised in the Discord server

## Was any impacted documentation updated to reflect this change?

[Kind of](https://github.com/5e-bits/docs/pull/142)

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/ac4c69cc-4f8d-4220-8c48-551e2f543107)
