### PR TITLE
fix(graphql): Spell DC now resolves to Ability Score

### DIFF
--- a/src/graphql/2014/resolvers/index.ts
+++ b/src/graphql/2014/resolvers/index.ts
@@ -34,7 +34,7 @@ import { RaceAbilityBonusResolver, RaceResolver } from './race/resolver'
 import { RuleResolver } from './rule/resolver'
 import { RuleSectionResolver } from './ruleSection/resolver'
 import { SkillResolver } from './skill/resolver'
-import { SpellDamageResolver, SpellResolver } from './spell/resolver'
+import { SpellDamageResolver, SpellResolver, SpellDCResolver } from './spell/resolver'
 import { SubclassResolver, SubclassSpellResolver } from './subclass/resolver'
 import { SubraceAbilityBonusResolver, SubraceResolver } from './subrace/resolver'
 import { ActionDamageResolver, TraitResolver, TraitSpecificResolver } from './trait/resolver'
@@ -90,6 +90,7 @@ const fieldResolvers = [
   SubclassSpellResolver,
   // Spell
   SpellDamageResolver,
+  SpellDCResolver,
   // Equipment
   ContentFieldResolver,
   // Monster Field Resolvers

--- a/src/graphql/2014/resolvers/spell/resolver.ts
+++ b/src/graphql/2014/resolvers/spell/resolver.ts
@@ -5,10 +5,11 @@ import { buildSortPipeline } from '@/graphql/common/args'
 import { buildMongoQueryFromNumberFilter } from '@/graphql/common/inputs'
 import { LevelValue } from '@/graphql/common/types'
 import { resolveMultipleReferences, resolveSingleReference } from '@/graphql/utils/resolvers'
+import AbilityScoreModel, { AbilityScore } from '@/models/2014/abilityScore'
 import ClassModel, { Class } from '@/models/2014/class'
 import DamageTypeModel, { DamageType } from '@/models/2014/damageType'
 import MagicSchoolModel, { MagicSchool } from '@/models/2014/magicSchool'
-import SpellModel, { Spell, SpellDamage } from '@/models/2014/spell'
+import SpellModel, { Spell, SpellDamage, SpellDC } from '@/models/2014/spell'
 import SubclassModel, { Subclass } from '@/models/2014/subclass'
 import { escapeRegExp } from '@/util'
 
@@ -148,5 +149,13 @@ export class SpellDamageResolver {
   })
   async damage_at_character_level(@Root() spellDamage: SpellDamage): Promise<LevelValue[] | null> {
     return mapLevelObjectToArray(spellDamage.damage_at_character_level)
+  }
+}
+
+@Resolver(SpellDC)
+export class SpellDCResolver {
+  @FieldResolver(() => AbilityScore, { nullable: true })
+  async dc_type(@Root() spellDC: SpellDC): Promise<AbilityScore | null> {
+    return resolveSingleReference(spellDC.dc_type, AbilityScoreModel)
   }
 }


### PR DESCRIPTION
## What does this do?

Fixes this query:
```
query SpellQuery {
  spells {
    dc {
      desc
      dc_success
      dc_type {
        full_name
      }
    }
  }
}
```

`dc_type` was not resolving to `AbilityScore` and was just returning the `APIReference`.

## How was it tested?

Locally running the graphql sandbox

## Is there a Github issue this is resolving?

Nope. Raised in `#help` in the Discord

## Was any impacted documentation updated to reflect this change?

Nope

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/3bce4409-c0c7-4b4d-9eb7-f12721ac4e8b)
