### PR TITLE
Bagelbits.simple table hookup 2024

### DIFF
--- a/src/graphql/2024/resolvers/alignment/args.ts
+++ b/src/graphql/2024/resolvers/alignment/args.ts
@@ -1,0 +1,58 @@
+import { ArgsType, Field, InputType, registerEnumType } from 'type-graphql'
+import { z } from 'zod'
+
+import {
+  BaseFilterArgs,
+  BaseFilterArgsSchema,
+  BaseIndexArgsSchema,
+  BaseOrderInterface
+} from '@/graphql/common/args'
+import { OrderByDirection } from '@/graphql/common/enums'
+
+export enum AlignmentOrderField {
+  NAME = 'name'
+}
+
+export const ALIGNMENT_SORT_FIELD_MAP: Record<AlignmentOrderField, string> = {
+  [AlignmentOrderField.NAME]: 'name'
+}
+
+registerEnumType(AlignmentOrderField, {
+  name: 'AlignmentOrderField',
+  description: 'Fields to sort Alignments by'
+})
+
+@InputType()
+export class AlignmentOrder implements BaseOrderInterface<AlignmentOrderField> {
+  @Field(() => AlignmentOrderField)
+  by!: AlignmentOrderField
+
+  @Field(() => OrderByDirection)
+  direction!: OrderByDirection
+
+  @Field(() => AlignmentOrder, { nullable: true })
+  then_by?: AlignmentOrder
+}
+
+export const AlignmentOrderSchema: z.ZodType<AlignmentOrder> = z.lazy(() =>
+  z.object({
+    by: z.nativeEnum(AlignmentOrderField),
+    direction: z.nativeEnum(OrderByDirection),
+    then_by: AlignmentOrderSchema.optional()
+  })
+)
+
+export const AlignmentArgsSchema = BaseFilterArgsSchema.extend({
+  order: AlignmentOrderSchema.optional()
+})
+
+export const AlignmentIndexArgsSchema = BaseIndexArgsSchema
+
+@ArgsType()
+export class AlignmentArgs extends BaseFilterArgs {
+  @Field(() => AlignmentOrder, {
+    nullable: true,
+    description: 'Specify sorting order for alignments.'
+  })
+  order?: AlignmentOrder
+}

--- a/src/graphql/2024/resolvers/alignment/resolver.ts
+++ b/src/graphql/2024/resolvers/alignment/resolver.ts
@@ -1,0 +1,57 @@
+import { Arg, Args, Query, Resolver } from 'type-graphql'
+
+import { buildSortPipeline } from '@/graphql/common/args'
+import AlignmentModel, { Alignment2024 } from '@/models/2024/alignment'
+import { escapeRegExp } from '@/util'
+
+import {
+  ALIGNMENT_SORT_FIELD_MAP,
+  AlignmentArgs,
+  AlignmentArgsSchema,
+  AlignmentIndexArgsSchema,
+  AlignmentOrderField
+} from './args'
+
+@Resolver(Alignment2024)
+export class AlignmentResolver {
+  @Query(() => [Alignment2024], {
+    description: 'Gets all alignments, optionally filtered by name and sorted.'
+  })
+  async alignments(@Args(() => AlignmentArgs) args: AlignmentArgs): Promise<Alignment2024[]> {
+    const validatedArgs = AlignmentArgsSchema.parse(args)
+
+    const query = AlignmentModel.find()
+
+    if (validatedArgs.name != null && validatedArgs.name !== '') {
+      query.where({ name: { $regex: new RegExp(escapeRegExp(validatedArgs.name), 'i') } })
+    }
+
+    const sortQuery = buildSortPipeline<AlignmentOrderField>({
+      order: validatedArgs.order,
+      sortFieldMap: ALIGNMENT_SORT_FIELD_MAP,
+      defaultSortField: AlignmentOrderField.NAME
+    })
+
+    if (Object.keys(sortQuery).length > 0) {
+      query.sort(sortQuery)
+    }
+
+    if (validatedArgs.skip) {
+      query.skip(validatedArgs.skip)
+    }
+    if (validatedArgs.limit) {
+      query.limit(validatedArgs.limit)
+    }
+
+    return query.lean()
+  }
+
+  @Query(() => Alignment2024, {
+    nullable: true,
+    description: 'Gets a single alignment by index.'
+  })
+  async alignment(@Arg('index', () => String) indexInput: string): Promise<Alignment2024 | null> {
+    const { index } = AlignmentIndexArgsSchema.parse({ index: indexInput })
+    return AlignmentModel.findOne({ index }).lean()
+  }
+}

--- a/src/graphql/2024/resolvers/condition/args.ts
+++ b/src/graphql/2024/resolvers/condition/args.ts
@@ -1,0 +1,58 @@
+import { ArgsType, Field, InputType, registerEnumType } from 'type-graphql'
+import { z } from 'zod'
+
+import {
+  BaseFilterArgs,
+  BaseFilterArgsSchema,
+  BaseIndexArgsSchema,
+  BaseOrderInterface
+} from '@/graphql/common/args'
+import { OrderByDirection } from '@/graphql/common/enums'
+
+export enum ConditionOrderField {
+  NAME = 'name'
+}
+
+export const CONDITION_SORT_FIELD_MAP: Record<ConditionOrderField, string> = {
+  [ConditionOrderField.NAME]: 'name'
+}
+
+registerEnumType(ConditionOrderField, {
+  name: 'ConditionOrderField',
+  description: 'Fields to sort Conditions by'
+})
+
+@InputType()
+export class ConditionOrder implements BaseOrderInterface<ConditionOrderField> {
+  @Field(() => ConditionOrderField)
+  by!: ConditionOrderField
+
+  @Field(() => OrderByDirection)
+  direction!: OrderByDirection
+
+  @Field(() => ConditionOrder, { nullable: true })
+  then_by?: ConditionOrder
+}
+
+export const ConditionOrderSchema: z.ZodType<ConditionOrder> = z.lazy(() =>
+  z.object({
+    by: z.nativeEnum(ConditionOrderField),
+    direction: z.nativeEnum(OrderByDirection),
+    then_by: ConditionOrderSchema.optional()
+  })
+)
+
+export const ConditionArgsSchema = BaseFilterArgsSchema.extend({
+  order: ConditionOrderSchema.optional()
+})
+
+export const ConditionIndexArgsSchema = BaseIndexArgsSchema
+
+@ArgsType()
+export class ConditionArgs extends BaseFilterArgs {
+  @Field(() => ConditionOrder, {
+    nullable: true,
+    description: 'Specify sorting order for conditions.'
+  })
+  order?: ConditionOrder
+}

--- a/src/graphql/2024/resolvers/condition/resolver.ts
+++ b/src/graphql/2024/resolvers/condition/resolver.ts
@@ -1,0 +1,56 @@
+import { Arg, Args, Query, Resolver } from 'type-graphql'
+
+import { buildSortPipeline } from '@/graphql/common/args'
+import ConditionModel, { Condition2024 } from '@/models/2024/condition'
+import { escapeRegExp } from '@/util'
+
+import {
+  CONDITION_SORT_FIELD_MAP,
+  ConditionArgs,
+  ConditionArgsSchema,
+  ConditionIndexArgsSchema,
+  ConditionOrderField
+} from './args'
+
+@Resolver(Condition2024)
+export class ConditionResolver {
+  @Query(() => [Condition2024], {
+    description: 'Gets all conditions, optionally filtered by name and sorted by name.'
+  })
+  async conditions(@Args(() => ConditionArgs) args: ConditionArgs): Promise<Condition2024[]> {
+    const validatedArgs = ConditionArgsSchema.parse(args)
+    const query = ConditionModel.find()
+
+    if (validatedArgs.name != null && validatedArgs.name !== '') {
+      query.where({ name: { $regex: new RegExp(escapeRegExp(validatedArgs.name), 'i') } })
+    }
+
+    const sortQuery = buildSortPipeline<ConditionOrderField>({
+      order: validatedArgs.order,
+      sortFieldMap: CONDITION_SORT_FIELD_MAP,
+      defaultSortField: ConditionOrderField.NAME
+    })
+
+    if (Object.keys(sortQuery).length > 0) {
+      query.sort(sortQuery)
+    }
+
+    if (validatedArgs.skip) {
+      query.skip(validatedArgs.skip)
+    }
+    if (validatedArgs.limit) {
+      query.limit(validatedArgs.limit)
+    }
+
+    return query.lean()
+  }
+
+  @Query(() => Condition2024, {
+    nullable: true,
+    description: 'Gets a single condition by index.'
+  })
+  async condition(@Arg('index', () => String) indexInput: string): Promise<Condition2024 | null> {
+    const { index } = ConditionIndexArgsSchema.parse({ index: indexInput })
+    return ConditionModel.findOne({ index }).lean()
+  }
+}

--- a/src/graphql/2024/resolvers/damageType/args.ts
+++ b/src/graphql/2024/resolvers/damageType/args.ts
@@ -1,0 +1,58 @@
+import { ArgsType, Field, InputType, registerEnumType } from 'type-graphql'
+import { z } from 'zod'
+
+import {
+  BaseFilterArgs,
+  BaseFilterArgsSchema,
+  BaseIndexArgsSchema,
+  BaseOrderInterface
+} from '@/graphql/common/args'
+import { OrderByDirection } from '@/graphql/common/enums'
+
+export enum DamageTypeOrderField {
+  NAME = 'name'
+}
+
+export const DAMAGE_TYPE_SORT_FIELD_MAP: Record<DamageTypeOrderField, string> = {
+  [DamageTypeOrderField.NAME]: 'name'
+}
+
+registerEnumType(DamageTypeOrderField, {
+  name: 'DamageTypeOrderField',
+  description: 'Fields to sort Damage Types by'
+})
+
+@InputType()
+export class DamageTypeOrder implements BaseOrderInterface<DamageTypeOrderField> {
+  @Field(() => DamageTypeOrderField)
+  by!: DamageTypeOrderField
+
+  @Field(() => OrderByDirection)
+  direction!: OrderByDirection
+
+  @Field(() => DamageTypeOrder, { nullable: true })
+  then_by?: DamageTypeOrder
+}
+
+export const DamageTypeOrderSchema: z.ZodType<DamageTypeOrder> = z.lazy(() =>
+  z.object({
+    by: z.nativeEnum(DamageTypeOrderField),
+    direction: z.nativeEnum(OrderByDirection),
+    then_by: DamageTypeOrderSchema.optional()
+  })
+)
+
+export const DamageTypeArgsSchema = BaseFilterArgsSchema.extend({
+  order: DamageTypeOrderSchema.optional()
+})
+
+export const DamageTypeIndexArgsSchema = BaseIndexArgsSchema
+
+@ArgsType()
+export class DamageTypeArgs extends BaseFilterArgs {
+  @Field(() => DamageTypeOrder, {
+    nullable: true,
+    description: 'Specify sorting order for damage types.'
+  })
+  order?: DamageTypeOrder
+}

--- a/src/graphql/2024/resolvers/damageType/resolver.ts
+++ b/src/graphql/2024/resolvers/damageType/resolver.ts
@@ -1,0 +1,56 @@
+import { Arg, Args, Query, Resolver } from 'type-graphql'
+
+import { buildSortPipeline } from '@/graphql/common/args'
+import DamageTypeModel, { DamageType2024 } from '@/models/2024/damageType'
+import { escapeRegExp } from '@/util'
+
+import {
+  DAMAGE_TYPE_SORT_FIELD_MAP,
+  DamageTypeArgs,
+  DamageTypeArgsSchema,
+  DamageTypeIndexArgsSchema,
+  DamageTypeOrderField
+} from './args'
+
+@Resolver(DamageType2024)
+export class DamageTypeResolver {
+  @Query(() => [DamageType2024], {
+    description: 'Gets all damage types, optionally filtered by name and sorted by name.'
+  })
+  async damageTypes(@Args(() => DamageTypeArgs) args: DamageTypeArgs): Promise<DamageType2024[]> {
+    const validatedArgs = DamageTypeArgsSchema.parse(args)
+    const query = DamageTypeModel.find()
+
+    if (validatedArgs.name != null && validatedArgs.name !== '') {
+      query.where({ name: { $regex: new RegExp(escapeRegExp(validatedArgs.name), 'i') } })
+    }
+
+    const sortQuery = buildSortPipeline<DamageTypeOrderField>({
+      order: validatedArgs.order,
+      sortFieldMap: DAMAGE_TYPE_SORT_FIELD_MAP,
+      defaultSortField: DamageTypeOrderField.NAME
+    })
+
+    if (Object.keys(sortQuery).length > 0) {
+      query.sort(sortQuery)
+    }
+
+    if (validatedArgs.skip) {
+      query.skip(validatedArgs.skip)
+    }
+    if (validatedArgs.limit) {
+      query.limit(validatedArgs.limit)
+    }
+
+    return query.lean()
+  }
+
+  @Query(() => DamageType2024, {
+    nullable: true,
+    description: 'Gets a single damage type by index.'
+  })
+  async damageType(@Arg('index', () => String) indexInput: string): Promise<DamageType2024 | null> {
+    const { index } = DamageTypeIndexArgsSchema.parse({ index: indexInput })
+    return DamageTypeModel.findOne({ index }).lean()
+  }
+}

--- a/src/graphql/2024/resolvers/index.ts
+++ b/src/graphql/2024/resolvers/index.ts
@@ -3,6 +3,7 @@ import { AlignmentResolver } from './alignment/resolver'
 import { ConditionResolver } from './condition/resolver'
 import { DamageTypeResolver } from './damageType/resolver'
 import { LanguageResolver } from './language/resolver'
+import { MagicSchoolResolver } from './magicSchool/resolver'
 import { SkillResolver } from './skill/resolver'
 
 const collectionResolvers = [
@@ -11,6 +12,7 @@ const collectionResolvers = [
   ConditionResolver,
   DamageTypeResolver,
   LanguageResolver,
+  MagicSchoolResolver,
   SkillResolver
 ] as const
 const fieldResolvers = [] as const

--- a/src/graphql/2024/resolvers/index.ts
+++ b/src/graphql/2024/resolvers/index.ts
@@ -1,7 +1,14 @@
 import { AbilityScoreResolver } from './abilityScore/resolver'
+import { AlignmentResolver } from './alignment/resolver'
+import { ConditionResolver } from './condition/resolver'
 import { SkillResolver } from './skill/resolver'
 
-const collectionResolvers = [AbilityScoreResolver, SkillResolver] as const
+const collectionResolvers = [
+  AbilityScoreResolver,
+  AlignmentResolver,
+  ConditionResolver,
+  SkillResolver
+] as const
 const fieldResolvers = [] as const
 
 export const resolvers = [...collectionResolvers, ...fieldResolvers] as const

--- a/src/graphql/2024/resolvers/index.ts
+++ b/src/graphql/2024/resolvers/index.ts
@@ -2,6 +2,7 @@ import { AbilityScoreResolver } from './abilityScore/resolver'
 import { AlignmentResolver } from './alignment/resolver'
 import { ConditionResolver } from './condition/resolver'
 import { DamageTypeResolver } from './damageType/resolver'
+import { LanguageResolver } from './language/resolver'
 import { SkillResolver } from './skill/resolver'
 
 const collectionResolvers = [
@@ -9,6 +10,7 @@ const collectionResolvers = [
   AlignmentResolver,
   ConditionResolver,
   DamageTypeResolver,
+  LanguageResolver,
   SkillResolver
 ] as const
 const fieldResolvers = [] as const

--- a/src/graphql/2024/resolvers/index.ts
+++ b/src/graphql/2024/resolvers/index.ts
@@ -5,6 +5,7 @@ import { DamageTypeResolver } from './damageType/resolver'
 import { LanguageResolver } from './language/resolver'
 import { MagicSchoolResolver } from './magicSchool/resolver'
 import { SkillResolver } from './skill/resolver'
+import { WeaponPropertyResolver } from './weaponProperty/resolver'
 
 const collectionResolvers = [
   AbilityScoreResolver,
@@ -13,7 +14,8 @@ const collectionResolvers = [
   DamageTypeResolver,
   LanguageResolver,
   MagicSchoolResolver,
-  SkillResolver
+  SkillResolver,
+  WeaponPropertyResolver
 ] as const
 const fieldResolvers = [] as const
 

--- a/src/graphql/2024/resolvers/index.ts
+++ b/src/graphql/2024/resolvers/index.ts
@@ -5,6 +5,7 @@ import { DamageTypeResolver } from './damageType/resolver'
 import { LanguageResolver } from './language/resolver'
 import { MagicSchoolResolver } from './magicSchool/resolver'
 import { SkillResolver } from './skill/resolver'
+import { WeaponMasteryPropertyResolver } from './weaponMasteryProperty/resolver'
 import { WeaponPropertyResolver } from './weaponProperty/resolver'
 
 const collectionResolvers = [
@@ -15,6 +16,7 @@ const collectionResolvers = [
   LanguageResolver,
   MagicSchoolResolver,
   SkillResolver,
+  WeaponMasteryPropertyResolver,
   WeaponPropertyResolver
 ] as const
 const fieldResolvers = [] as const

--- a/src/graphql/2024/resolvers/index.ts
+++ b/src/graphql/2024/resolvers/index.ts
@@ -1,12 +1,14 @@
 import { AbilityScoreResolver } from './abilityScore/resolver'
 import { AlignmentResolver } from './alignment/resolver'
 import { ConditionResolver } from './condition/resolver'
+import { DamageTypeResolver } from './damageType/resolver'
 import { SkillResolver } from './skill/resolver'
 
 const collectionResolvers = [
   AbilityScoreResolver,
   AlignmentResolver,
   ConditionResolver,
+  DamageTypeResolver,
   SkillResolver
 ] as const
 const fieldResolvers = [] as const

--- a/src/graphql/2024/resolvers/language/args.ts
+++ b/src/graphql/2024/resolvers/language/args.ts
@@ -1,0 +1,77 @@
+import { ArgsType, Field, InputType, registerEnumType } from 'type-graphql'
+import { z } from 'zod'
+
+import {
+  BaseFilterArgs,
+  BaseFilterArgsSchema,
+  BaseIndexArgsSchema,
+  BaseOrderInterface
+} from '@/graphql/common/args'
+import { OrderByDirection } from '@/graphql/common/enums'
+
+export enum LanguageOrderField {
+  NAME = 'name',
+  TYPE = 'type',
+  SCRIPT = 'script'
+}
+
+export const LANGUAGE_SORT_FIELD_MAP: Record<LanguageOrderField, string> = {
+  [LanguageOrderField.NAME]: 'name',
+  [LanguageOrderField.TYPE]: 'type',
+  [LanguageOrderField.SCRIPT]: 'script'
+}
+
+registerEnumType(LanguageOrderField, {
+  name: 'LanguageOrderField',
+  description: 'Fields to sort Languages by'
+})
+
+@InputType()
+export class LanguageOrder implements BaseOrderInterface<LanguageOrderField> {
+  @Field(() => LanguageOrderField)
+  by!: LanguageOrderField
+
+  @Field(() => OrderByDirection)
+  direction!: OrderByDirection
+
+  @Field(() => LanguageOrder, { nullable: true })
+  then_by?: LanguageOrder
+}
+
+export const LanguageOrderSchema: z.ZodType<LanguageOrder> = z.lazy(() =>
+  z.object({
+    by: z.nativeEnum(LanguageOrderField),
+    direction: z.nativeEnum(OrderByDirection),
+    then_by: LanguageOrderSchema.optional()
+  })
+)
+
+export const LanguageArgsSchema = BaseFilterArgsSchema.extend({
+  type: z.string().optional(),
+  script: z.array(z.string()).optional(),
+  order: LanguageOrderSchema.optional()
+})
+
+export const LanguageIndexArgsSchema = BaseIndexArgsSchema
+
+@ArgsType()
+export class LanguageArgs extends BaseFilterArgs {
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Filter by language type (e.g., Standard, Exotic) - case-insensitive exact match after normalization'
+  })
+  type?: string
+
+  @Field(() => [String], {
+    nullable: true,
+    description: 'Filter by one or more language scripts (e.g., ["Common", "Elvish"])'
+  })
+  script?: string[]
+
+  @Field(() => LanguageOrder, {
+    nullable: true,
+    description: 'Specify sorting order for languages.'
+  })
+  order?: LanguageOrder
+}

--- a/src/graphql/2024/resolvers/language/resolver.ts
+++ b/src/graphql/2024/resolvers/language/resolver.ts
@@ -1,0 +1,69 @@
+import { Arg, Args, Query, Resolver } from 'type-graphql'
+
+import { buildSortPipeline } from '@/graphql/common/args'
+import LanguageModel, { Language2024 } from '@/models/2024/language'
+import { escapeRegExp } from '@/util'
+
+import {
+  LANGUAGE_SORT_FIELD_MAP,
+  LanguageArgs,
+  LanguageArgsSchema,
+  LanguageIndexArgsSchema,
+  LanguageOrderField
+} from './args'
+
+@Resolver(Language2024)
+export class LanguageResolver {
+  @Query(() => Language2024, {
+    nullable: true,
+    description: 'Gets a single language by its index.'
+  })
+  async language(@Arg('index', () => String) indexInput: string): Promise<Language2024 | null> {
+    const { index } = LanguageIndexArgsSchema.parse({ index: indexInput })
+    return LanguageModel.findOne({ index }).lean()
+  }
+
+  @Query(() => [Language2024], {
+    description: 'Gets all languages, optionally filtered and sorted.'
+  })
+  async languages(@Args(() => LanguageArgs) args: LanguageArgs): Promise<Language2024[]> {
+    const validatedArgs = LanguageArgsSchema.parse(args)
+
+    const query = LanguageModel.find()
+    const filters: any[] = []
+
+    if (validatedArgs.name != null && validatedArgs.name !== '') {
+      filters.push({ name: { $regex: new RegExp(escapeRegExp(validatedArgs.name), 'i') } })
+    }
+
+    if (validatedArgs.type != null && validatedArgs.type !== '') {
+      filters.push({ type: { $regex: new RegExp(escapeRegExp(validatedArgs.type), 'i') } })
+    }
+
+    if (validatedArgs.script && validatedArgs.script.length > 0) {
+      filters.push({ script: { $in: validatedArgs.script } })
+    }
+
+    if (filters.length > 0) {
+      query.where({ $and: filters })
+    }
+
+    const sortQuery = buildSortPipeline<LanguageOrderField>({
+      order: validatedArgs.order,
+      sortFieldMap: LANGUAGE_SORT_FIELD_MAP,
+      defaultSortField: LanguageOrderField.NAME
+    })
+    if (Object.keys(sortQuery).length > 0) {
+      query.sort(sortQuery)
+    }
+
+    if (validatedArgs.skip !== undefined) {
+      query.skip(validatedArgs.skip)
+    }
+    if (validatedArgs.limit !== undefined) {
+      query.limit(validatedArgs.limit)
+    }
+
+    return query.lean()
+  }
+}

--- a/src/graphql/2024/resolvers/magicSchool/args.ts
+++ b/src/graphql/2024/resolvers/magicSchool/args.ts
@@ -1,0 +1,58 @@
+import { ArgsType, Field, InputType, registerEnumType } from 'type-graphql'
+import { z } from 'zod'
+
+import {
+  BaseFilterArgs,
+  BaseFilterArgsSchema,
+  BaseIndexArgsSchema,
+  BaseOrderInterface
+} from '@/graphql/common/args'
+import { OrderByDirection } from '@/graphql/common/enums'
+
+export enum MagicSchoolOrderField {
+  NAME = 'name'
+}
+
+export const MAGIC_SCHOOL_SORT_FIELD_MAP: Record<MagicSchoolOrderField, string> = {
+  [MagicSchoolOrderField.NAME]: 'name'
+}
+
+registerEnumType(MagicSchoolOrderField, {
+  name: 'MagicSchoolOrderField',
+  description: 'Fields to sort Magic Schools by'
+})
+
+@InputType()
+export class MagicSchoolOrder implements BaseOrderInterface<MagicSchoolOrderField> {
+  @Field(() => MagicSchoolOrderField)
+  by!: MagicSchoolOrderField
+
+  @Field(() => OrderByDirection)
+  direction!: OrderByDirection
+
+  @Field(() => MagicSchoolOrder, { nullable: true })
+  then_by?: MagicSchoolOrder
+}
+
+export const MagicSchoolOrderSchema: z.ZodType<MagicSchoolOrder> = z.lazy(() =>
+  z.object({
+    by: z.nativeEnum(MagicSchoolOrderField),
+    direction: z.nativeEnum(OrderByDirection),
+    then_by: MagicSchoolOrderSchema.optional()
+  })
+)
+
+export const MagicSchoolArgsSchema = BaseFilterArgsSchema.extend({
+  order: MagicSchoolOrderSchema.optional()
+})
+
+export const MagicSchoolIndexArgsSchema = BaseIndexArgsSchema
+
+@ArgsType()
+export class MagicSchoolArgs extends BaseFilterArgs {
+  @Field(() => MagicSchoolOrder, {
+    nullable: true,
+    description: 'Specify sorting order for magic schools.'
+  })
+  order?: MagicSchoolOrder
+}

--- a/src/graphql/2024/resolvers/magicSchool/resolver.ts
+++ b/src/graphql/2024/resolvers/magicSchool/resolver.ts
@@ -1,0 +1,60 @@
+import { Arg, Args, Query, Resolver } from 'type-graphql'
+
+import { buildSortPipeline } from '@/graphql/common/args'
+import MagicSchoolModel, { MagicSchool2024 } from '@/models/2024/magicSchool'
+import { escapeRegExp } from '@/util'
+
+import {
+  MAGIC_SCHOOL_SORT_FIELD_MAP,
+  MagicSchoolArgs,
+  MagicSchoolArgsSchema,
+  MagicSchoolIndexArgsSchema,
+  MagicSchoolOrderField
+} from './args'
+
+@Resolver(MagicSchool2024)
+export class MagicSchoolResolver {
+  @Query(() => [MagicSchool2024], {
+    description: 'Gets all magic schools, optionally filtered by name and sorted by name.'
+  })
+  async magicSchools(
+    @Args(() => MagicSchoolArgs) args: MagicSchoolArgs
+  ): Promise<MagicSchool2024[]> {
+    const validatedArgs = MagicSchoolArgsSchema.parse(args)
+    const query = MagicSchoolModel.find()
+
+    if (validatedArgs.name != null && validatedArgs.name !== '') {
+      query.where({ name: { $regex: new RegExp(escapeRegExp(validatedArgs.name), 'i') } })
+    }
+
+    const sortQuery = buildSortPipeline<MagicSchoolOrderField>({
+      order: validatedArgs.order,
+      sortFieldMap: MAGIC_SCHOOL_SORT_FIELD_MAP,
+      defaultSortField: MagicSchoolOrderField.NAME
+    })
+
+    if (Object.keys(sortQuery).length > 0) {
+      query.sort(sortQuery)
+    }
+
+    if (validatedArgs.skip) {
+      query.skip(validatedArgs.skip)
+    }
+    if (validatedArgs.limit) {
+      query.limit(validatedArgs.limit)
+    }
+
+    return query.lean()
+  }
+
+  @Query(() => MagicSchool2024, {
+    nullable: true,
+    description: 'Gets a single magic school by index.'
+  })
+  async magicSchool(
+    @Arg('index', () => String) indexInput: string
+  ): Promise<MagicSchool2024 | null> {
+    const { index } = MagicSchoolIndexArgsSchema.parse({ index: indexInput })
+    return MagicSchoolModel.findOne({ index }).lean()
+  }
+}

--- a/src/graphql/2024/resolvers/weaponMasteryProperty/args.ts
+++ b/src/graphql/2024/resolvers/weaponMasteryProperty/args.ts
@@ -1,0 +1,63 @@
+import { ArgsType, Field, InputType, registerEnumType } from 'type-graphql'
+import { z } from 'zod'
+
+import {
+  BaseFilterArgs,
+  BaseFilterArgsSchema,
+  BaseIndexArgsSchema,
+  BaseOrderInterface
+} from '@/graphql/common/args'
+import { OrderByDirection } from '@/graphql/common/enums'
+
+export enum WeaponMasteryPropertyOrderField {
+  NAME = 'name'
+}
+
+export const WEAPON_MASTERY_PROPERTY_SORT_FIELD_MAP: Record<
+  WeaponMasteryPropertyOrderField,
+  string
+> = {
+  [WeaponMasteryPropertyOrderField.NAME]: 'name'
+}
+
+registerEnumType(WeaponMasteryPropertyOrderField, {
+  name: 'WeaponMasteryPropertyOrderField',
+  description: 'Fields to sort Weapon Mastery Properties by'
+})
+
+@InputType()
+export class WeaponMasteryPropertyOrder
+  implements BaseOrderInterface<WeaponMasteryPropertyOrderField>
+{
+  @Field(() => WeaponMasteryPropertyOrderField)
+  by!: WeaponMasteryPropertyOrderField
+
+  @Field(() => OrderByDirection)
+  direction!: OrderByDirection
+
+  @Field(() => WeaponMasteryPropertyOrder, { nullable: true })
+  then_by?: WeaponMasteryPropertyOrder
+}
+
+export const WeaponMasteryPropertyOrderSchema: z.ZodType<WeaponMasteryPropertyOrder> = z.lazy(() =>
+  z.object({
+    by: z.nativeEnum(WeaponMasteryPropertyOrderField),
+    direction: z.nativeEnum(OrderByDirection),
+    then_by: WeaponMasteryPropertyOrderSchema.optional()
+  })
+)
+
+export const WeaponMasteryPropertyArgsSchema = BaseFilterArgsSchema.extend({
+  order: WeaponMasteryPropertyOrderSchema.optional()
+})
+
+export const WeaponMasteryPropertyIndexArgsSchema = BaseIndexArgsSchema
+
+@ArgsType()
+export class WeaponMasteryPropertyArgs extends BaseFilterArgs {
+  @Field(() => WeaponMasteryPropertyOrder, {
+    nullable: true,
+    description: 'Specify sorting order for weapon mastery properties.'
+  })
+  order?: WeaponMasteryPropertyOrder
+}

--- a/src/graphql/2024/resolvers/weaponMasteryProperty/resolver.ts
+++ b/src/graphql/2024/resolvers/weaponMasteryProperty/resolver.ts
@@ -1,0 +1,63 @@
+import { Arg, Args, Query, Resolver } from 'type-graphql'
+
+import { buildSortPipeline } from '@/graphql/common/args'
+import WeaponMasteryPropertyModel, {
+  WeaponMasteryProperty2024
+} from '@/models/2024/weaponMasteryProperty'
+import { escapeRegExp } from '@/util'
+
+import {
+  WEAPON_MASTERY_PROPERTY_SORT_FIELD_MAP,
+  WeaponMasteryPropertyArgs,
+  WeaponMasteryPropertyArgsSchema,
+  WeaponMasteryPropertyIndexArgsSchema,
+  WeaponMasteryPropertyOrderField
+} from './args'
+
+@Resolver(WeaponMasteryProperty2024)
+export class WeaponMasteryPropertyResolver {
+  @Query(() => [WeaponMasteryProperty2024], {
+    description:
+      'Gets all weapon mastery properties, optionally filtered by name and sorted by name.'
+  })
+  async weaponMasteryProperties(
+    @Args(() => WeaponMasteryPropertyArgs) args: WeaponMasteryPropertyArgs
+  ): Promise<WeaponMasteryProperty2024[]> {
+    const validatedArgs = WeaponMasteryPropertyArgsSchema.parse(args)
+    const query = WeaponMasteryPropertyModel.find()
+
+    if (validatedArgs.name != null && validatedArgs.name !== '') {
+      query.where({ name: { $regex: new RegExp(escapeRegExp(validatedArgs.name), 'i') } })
+    }
+
+    const sortQuery = buildSortPipeline<WeaponMasteryPropertyOrderField>({
+      order: validatedArgs.order,
+      sortFieldMap: WEAPON_MASTERY_PROPERTY_SORT_FIELD_MAP,
+      defaultSortField: WeaponMasteryPropertyOrderField.NAME
+    })
+
+    if (Object.keys(sortQuery).length > 0) {
+      query.sort(sortQuery)
+    }
+
+    if (validatedArgs.skip) {
+      query.skip(validatedArgs.skip)
+    }
+    if (validatedArgs.limit) {
+      query.limit(validatedArgs.limit)
+    }
+
+    return query.lean()
+  }
+
+  @Query(() => WeaponMasteryProperty2024, {
+    nullable: true,
+    description: 'Gets a single weapon mastery property by index.'
+  })
+  async weaponMasteryProperty(
+    @Arg('index', () => String) indexInput: string
+  ): Promise<WeaponMasteryProperty2024 | null> {
+    const { index } = WeaponMasteryPropertyIndexArgsSchema.parse({ index: indexInput })
+    return WeaponMasteryPropertyModel.findOne({ index }).lean()
+  }
+}

--- a/src/graphql/2024/resolvers/weaponProperty/args.ts
+++ b/src/graphql/2024/resolvers/weaponProperty/args.ts
@@ -1,0 +1,58 @@
+import { ArgsType, Field, InputType, registerEnumType } from 'type-graphql'
+import { z } from 'zod'
+
+import {
+  BaseFilterArgs,
+  BaseFilterArgsSchema,
+  BaseIndexArgsSchema,
+  BaseOrderInterface
+} from '@/graphql/common/args'
+import { OrderByDirection } from '@/graphql/common/enums'
+
+export enum WeaponPropertyOrderField {
+  NAME = 'name'
+}
+
+export const WEAPON_PROPERTY_SORT_FIELD_MAP: Record<WeaponPropertyOrderField, string> = {
+  [WeaponPropertyOrderField.NAME]: 'name'
+}
+
+registerEnumType(WeaponPropertyOrderField, {
+  name: 'WeaponPropertyOrderField',
+  description: 'Fields to sort Weapon Properties by'
+})
+
+@InputType()
+export class WeaponPropertyOrder implements BaseOrderInterface<WeaponPropertyOrderField> {
+  @Field(() => WeaponPropertyOrderField)
+  by!: WeaponPropertyOrderField
+
+  @Field(() => OrderByDirection)
+  direction!: OrderByDirection
+
+  @Field(() => WeaponPropertyOrder, { nullable: true })
+  then_by?: WeaponPropertyOrder
+}
+
+export const WeaponPropertyOrderSchema: z.ZodType<WeaponPropertyOrder> = z.lazy(() =>
+  z.object({
+    by: z.nativeEnum(WeaponPropertyOrderField),
+    direction: z.nativeEnum(OrderByDirection),
+    then_by: WeaponPropertyOrderSchema.optional()
+  })
+)
+
+export const WeaponPropertyArgsSchema = BaseFilterArgsSchema.extend({
+  order: WeaponPropertyOrderSchema.optional()
+})
+
+export const WeaponPropertyIndexArgsSchema = BaseIndexArgsSchema
+
+@ArgsType()
+export class WeaponPropertyArgs extends BaseFilterArgs {
+  @Field(() => WeaponPropertyOrder, {
+    nullable: true,
+    description: 'Specify sorting order for weapon properties.'
+  })
+  order?: WeaponPropertyOrder
+}

--- a/src/graphql/2024/resolvers/weaponProperty/resolver.ts
+++ b/src/graphql/2024/resolvers/weaponProperty/resolver.ts
@@ -1,0 +1,60 @@
+import { Arg, Args, Query, Resolver } from 'type-graphql'
+
+import { buildSortPipeline } from '@/graphql/common/args'
+import WeaponPropertyModel, { WeaponProperty2024 } from '@/models/2024/weaponProperty'
+import { escapeRegExp } from '@/util'
+
+import {
+  WEAPON_PROPERTY_SORT_FIELD_MAP,
+  WeaponPropertyArgs,
+  WeaponPropertyArgsSchema,
+  WeaponPropertyIndexArgsSchema,
+  WeaponPropertyOrderField
+} from './args'
+
+@Resolver(WeaponProperty2024)
+export class WeaponPropertyResolver {
+  @Query(() => [WeaponProperty2024], {
+    description: 'Gets all weapon properties, optionally filtered by name and sorted by name.'
+  })
+  async weaponProperties(
+    @Args(() => WeaponPropertyArgs) args: WeaponPropertyArgs
+  ): Promise<WeaponProperty2024[]> {
+    const validatedArgs = WeaponPropertyArgsSchema.parse(args)
+    const query = WeaponPropertyModel.find()
+
+    if (validatedArgs.name != null && validatedArgs.name !== '') {
+      query.where({ name: { $regex: new RegExp(escapeRegExp(validatedArgs.name), 'i') } })
+    }
+
+    const sortQuery = buildSortPipeline<WeaponPropertyOrderField>({
+      order: validatedArgs.order,
+      sortFieldMap: WEAPON_PROPERTY_SORT_FIELD_MAP,
+      defaultSortField: WeaponPropertyOrderField.NAME
+    })
+
+    if (Object.keys(sortQuery).length > 0) {
+      query.sort(sortQuery)
+    }
+
+    if (validatedArgs.skip) {
+      query.skip(validatedArgs.skip)
+    }
+    if (validatedArgs.limit) {
+      query.limit(validatedArgs.limit)
+    }
+
+    return query.lean()
+  }
+
+  @Query(() => WeaponProperty2024, {
+    nullable: true,
+    description: 'Gets a single weapon property by index.'
+  })
+  async weaponProperty(
+    @Arg('index', () => String) indexInput: string
+  ): Promise<WeaponProperty2024 | null> {
+    const { index } = WeaponPropertyIndexArgsSchema.parse({ index: indexInput })
+    return WeaponPropertyModel.findOne({ index }).lean()
+  }
+}

--- a/src/models/2024/abilityScore.ts
+++ b/src/models/2024/abilityScore.ts
@@ -12,11 +12,11 @@ import { srdModelOptions } from '@/util/modelOptions'
 })
 @srdModelOptions('2024-ability-scores')
 export class AbilityScore2024 {
-  @Field(() => [String], {
+  @Field(() => String, {
     description: 'A description of the ability score and its applications.'
   })
-  @prop({ required: true, index: true, type: () => [String] })
-  public description!: string[]
+  @prop({ required: true, index: true, type: () => String })
+  public description!: string
 
   @Field(() => String, { description: 'The full name of the ability score (e.g., Strength).' })
   @prop({ required: true, index: true, type: () => String })

--- a/src/models/2024/alignment.ts
+++ b/src/models/2024/alignment.ts
@@ -1,0 +1,45 @@
+import { getModelForClass, prop } from '@typegoose/typegoose'
+import { DocumentType } from '@typegoose/typegoose/lib/types'
+import { Field, ObjectType } from 'type-graphql'
+
+import { srdModelOptions } from '@/util/modelOptions'
+
+@ObjectType({
+  description: "An alignment representing a character's moral and ethical beliefs."
+})
+@srdModelOptions('2024-alignments')
+export class Alignment2024 {
+  @Field(() => String, { description: 'A description of the alignment.' })
+  @prop({ required: true, index: true, type: () => String })
+  public description!: string
+
+  @Field(() => String, {
+    description: 'A shortened representation of the alignment (e.g., LG, CE).'
+  })
+  @prop({ required: true, index: true, type: () => String })
+  public abbreviation!: string
+
+  @Field(() => String, {
+    description: 'The unique identifier for this alignment (e.g., lawful-good).'
+  })
+  @prop({ required: true, index: true, type: () => String })
+  public index!: string
+
+  @Field(() => String, {
+    description: 'The name of the alignment (e.g., Lawful Good, Chaotic Evil).'
+  })
+  @prop({ required: true, index: true, type: () => String })
+  public name!: string
+
+  @prop({ required: true, index: true, type: () => String })
+  public url!: string
+
+  @Field(() => String, { description: 'Timestamp of the last update.' })
+  @prop({ required: true, index: true, type: () => String })
+  public updated_at!: string
+}
+
+export type AlignmentDocument = DocumentType<Alignment2024>
+const AlignmentModel = getModelForClass(Alignment2024)
+
+export default AlignmentModel

--- a/src/models/2024/condition.ts
+++ b/src/models/2024/condition.ts
@@ -1,0 +1,33 @@
+import { getModelForClass, prop } from '@typegoose/typegoose'
+import { DocumentType } from '@typegoose/typegoose/lib/types'
+import { Field, ObjectType } from 'type-graphql'
+
+import { srdModelOptions } from '@/util/modelOptions'
+
+@ObjectType({ description: 'A state that can affect a creature, such as Blinded or Prone.' })
+@srdModelOptions('2024-conditions')
+export class Condition2024 {
+  @Field(() => String, { description: 'The unique identifier for this condition (e.g., blinded).' })
+  @prop({ required: true, index: true, type: () => String })
+  public index!: string
+
+  @Field(() => String, { description: 'The name of the condition (e.g., Blinded).' })
+  @prop({ required: true, index: true, type: () => String })
+  public name!: string
+
+  @Field(() => String, { description: 'A description of the effects of the condition.' })
+  @prop({ required: true, type: () => String })
+  public description!: string
+
+  @prop({ required: true, index: true, type: () => String })
+  public url!: string
+
+  @Field(() => String, { description: 'Timestamp of the last update.' })
+  @prop({ required: true, index: true, type: () => String })
+  public updated_at!: string
+}
+
+export type ConditionDocument = DocumentType<Condition2024>
+const ConditionModel = getModelForClass(Condition2024)
+
+export default ConditionModel

--- a/src/models/2024/damageType.ts
+++ b/src/models/2024/damageType.ts
@@ -1,0 +1,33 @@
+import { getModelForClass, prop } from '@typegoose/typegoose'
+import { DocumentType } from '@typegoose/typegoose/lib/types'
+import { Field, ObjectType } from 'type-graphql'
+
+import { srdModelOptions } from '@/util/modelOptions'
+
+@ObjectType({ description: 'Represents a type of damage (e.g., Acid, Bludgeoning, Fire).' })
+@srdModelOptions('2024-damage-types')
+export class DamageType2024 {
+  @Field(() => String, { description: 'The unique identifier for this damage type (e.g., acid).' })
+  @prop({ required: true, index: true, type: () => String })
+  public index!: string
+
+  @Field(() => String, { description: 'The name of the damage type (e.g., Acid).' })
+  @prop({ required: true, index: true, type: () => String })
+  public name!: string
+
+  @Field(() => String, { description: 'A description of the damage type.' })
+  @prop({ required: true, type: () => String })
+  public description!: string
+
+  @prop({ required: true, index: true, type: () => String })
+  public url!: string
+
+  @Field(() => String, { description: 'Timestamp of the last update.' })
+  @prop({ required: true, index: true, type: () => String })
+  public updated_at!: string
+}
+
+export type DamageTypeDocument = DocumentType<DamageType2024>
+const DamageTypeModel = getModelForClass(DamageType2024)
+
+export default DamageTypeModel

--- a/src/models/2024/language.ts
+++ b/src/models/2024/language.ts
@@ -1,0 +1,37 @@
+import { getModelForClass, prop } from '@typegoose/typegoose'
+import { DocumentType } from '@typegoose/typegoose/lib/types'
+import { Field, ObjectType } from 'type-graphql'
+
+import { srdModelOptions } from '@/util/modelOptions'
+
+@ObjectType({ description: 'Represents a language spoken in the D&D world.' })
+@srdModelOptions('2024-languages')
+export class Language2024 {
+  @Field(() => String, { description: 'The unique identifier for this language (e.g., draconic).' })
+  @prop({ required: true, index: true, type: () => String })
+  public index!: string
+
+  @Field(() => String, { description: 'The name of the language (e.g., Draconic).' })
+  @prop({ required: true, index: true, type: () => String })
+  public name!: string
+
+  @Field(() => Boolean, { description: 'Whether the language is rare.' })
+  @prop({ required: true, index: true, type: () => Boolean })
+  public is_rare!: boolean
+
+  @Field(() => String, { description: 'A note about the language.' })
+  @prop({ required: true, index: true, type: () => String })
+  public note!: string
+
+  @prop({ required: true, index: true, type: () => String })
+  public url!: string
+
+  @Field(() => String, { description: 'Timestamp of the last update.' })
+  @prop({ required: true, index: true, type: () => String })
+  public updated_at!: string
+}
+
+export type LanguageDocument = DocumentType<Language2024>
+const LanguageModel = getModelForClass(Language2024)
+
+export default LanguageModel

--- a/src/models/2024/magicSchool.ts
+++ b/src/models/2024/magicSchool.ts
@@ -1,0 +1,35 @@
+import { getModelForClass, prop } from '@typegoose/typegoose'
+import { DocumentType } from '@typegoose/typegoose/lib/types'
+import { Field, ObjectType } from 'type-graphql'
+
+import { srdModelOptions } from '@/util/modelOptions'
+
+@ObjectType({
+  description: 'A school of magic, representing a particular tradition like Evocation or Illusion.'
+})
+@srdModelOptions('2024-magic-schools')
+export class MagicSchool2024 {
+  @Field(() => String, { description: 'A brief description of the school of magic.' })
+  @prop({ type: () => String, index: true })
+  public description!: string
+
+  @Field(() => String, { description: 'The unique identifier for this school (e.g., evocation).' })
+  @prop({ required: true, index: true, type: () => String })
+  public index!: string
+
+  @Field(() => String, { description: 'The name of the school (e.g., Evocation).' })
+  @prop({ required: true, index: true, type: () => String })
+  public name!: string
+
+  @prop({ required: true, index: true, type: () => String })
+  public url!: string
+
+  @Field(() => String, { description: 'Timestamp of the last update.' })
+  @prop({ required: true, index: true, type: () => String })
+  public updated_at!: string
+}
+
+export type MagicSchoolDocument = DocumentType<MagicSchool2024>
+const MagicSchoolModel = getModelForClass(MagicSchool2024)
+
+export default MagicSchoolModel

--- a/src/models/2024/skill.ts
+++ b/src/models/2024/skill.ts
@@ -16,9 +16,9 @@ export class Skill2024 {
   @prop({ type: () => APIReference, required: true })
   public ability_score!: APIReference
 
-  @Field(() => [String], { description: 'A description of the skill.' })
-  @prop({ required: true, index: true, type: () => [String] })
-  public description!: string[]
+  @Field(() => String, { description: 'A description of the skill.' })
+  @prop({ required: true, index: true, type: () => String })
+  public description!: string
 
   @Field(() => String, { description: 'The unique identifier for this skill (e.g., athletics).' })
   @prop({ required: true, index: true, type: () => String })

--- a/src/models/2024/weaponMasteryProperty.ts
+++ b/src/models/2024/weaponMasteryProperty.ts
@@ -1,0 +1,38 @@
+import { getModelForClass, prop } from '@typegoose/typegoose'
+import { DocumentType } from '@typegoose/typegoose/lib/types'
+import { Field, ObjectType } from 'type-graphql'
+
+import { srdModelOptions } from '@/util/modelOptions'
+
+@ObjectType({
+  description:
+    'Each weapon has a mastery property, which is usable only by a character who has a feature, such as Weapon Mastery, that unlocks the property for the character'
+})
+@srdModelOptions('2024-weapon-mastery-properties')
+export class WeaponMasteryProperty2024 {
+  @Field(() => String, { description: 'A description of the weapon mastery property.' })
+  @prop({ required: true, index: true, type: () => String })
+  public description!: string
+
+  @Field(() => String, {
+    description: 'The unique identifier for this mastery property (e.g., cleave).'
+  })
+  @prop({ required: true, index: true, type: () => String })
+  public index!: string
+
+  @Field(() => String, { description: 'The name of the mastery property (e.g., Cleave).' })
+  @prop({ required: true, index: true, type: () => String })
+  public name!: string
+
+  @prop({ required: true, index: true, type: () => String })
+  public url!: string
+
+  @Field(() => String, { description: 'Timestamp of the last update.' })
+  @prop({ required: true, index: true, type: () => String })
+  public updated_at!: string
+}
+
+export type WeaponMasteryPropertyDocument = DocumentType<WeaponMasteryProperty2024>
+const WeaponMasteryPropertyModel = getModelForClass(WeaponMasteryProperty2024)
+
+export default WeaponMasteryPropertyModel

--- a/src/models/2024/weaponProperty.ts
+++ b/src/models/2024/weaponProperty.ts
@@ -1,0 +1,37 @@
+import { getModelForClass, prop } from '@typegoose/typegoose'
+import { DocumentType } from '@typegoose/typegoose/lib/types'
+import { Field, ObjectType } from 'type-graphql'
+
+import { srdModelOptions } from '@/util/modelOptions'
+
+@ObjectType({
+  description: 'A property that can be applied to a weapon, modifying its use or characteristics.'
+})
+@srdModelOptions('2024-weapon-properties')
+export class WeaponProperty2024 {
+  @Field(() => String, { description: 'A description of the weapon property.' })
+  @prop({ required: true, index: true, type: () => String })
+  public description!: string
+
+  @Field(() => String, {
+    description: 'The unique identifier for this property (e.g., versatile).'
+  })
+  @prop({ required: true, index: true, type: () => String })
+  public index!: string
+
+  @Field(() => String, { description: 'The name of the property (e.g., Versatile).' })
+  @prop({ required: true, index: true, type: () => String })
+  public name!: string
+
+  @prop({ required: true, index: true, type: () => String })
+  public url!: string
+
+  @Field(() => String, { description: 'Timestamp of the last update.' })
+  @prop({ required: true, index: true, type: () => String })
+  public updated_at!: string
+}
+
+export type WeaponPropertyDocument = DocumentType<WeaponProperty2024>
+const WeaponPropertyModel = getModelForClass(WeaponProperty2024)
+
+export default WeaponPropertyModel


### PR DESCRIPTION
## What does this do?

Adds 2024 endpoints and graphql queries for the following new tables:
* Magic Schools
* Damage types
* Conditions
* Weapon Properties
* Weapon Mastery Properties
* Alignments
* Languages

## How was it tested?

\<It's not clear if I don't update this text with relevant info\>

## Was any impacted documentation updated to reflect this change?

Not yet

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/260b143c-e0b6-4823-86c0-5770981db414)
