### PR TITLE
fix(races): Language options is optional for graphql

### DIFF
--- a/src/graphql/2014/utils/resolvers.ts
+++ b/src/graphql/2014/utils/resolvers.ts
@@ -16,8 +16,14 @@ import {
   ReferenceOption
 } from '@/models/common/choice'
 
-export async function resolveLanguageChoice(choiceData: Choice): Promise<LanguageChoice | null> {
+export async function resolveLanguageChoice(
+  choiceData: Choice | null
+): Promise<LanguageChoice | null> {
   const gqlEmbeddedOptions: LanguageChoiceOption[] = []
+
+  if (!choiceData) {
+    return null
+  }
 
   if (choiceData.from.option_set_type === 'resource_list') {
     const allItems = (await LanguageModel.find({}).lean()) as Language[]


### PR DESCRIPTION
## What does this do?

Fixes the GraphQL resolver to handle `language_options` being optional on races.

## How was it tested?

Locally

## Is there a Github issue this is resolving?

Raised in the Discord

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/6837b7fb-533a-47a6-ae6c-9856fc04932c)
