### PR TITLE
refactor(race/subrace): remove redundant data

### DIFF
--- a/src/graphql/2014/resolvers/race/resolver.ts
+++ b/src/graphql/2014/resolvers/race/resolver.ts
@@ -3,8 +3,7 @@ import { Arg, Args, FieldResolver, Query, Resolver, Root } from 'type-graphql'
 import {
   AbilityScoreBonusChoice,
   AbilityScoreBonusChoiceOption,
-  LanguageChoice,
-  ProficiencyChoice
+  LanguageChoice
 } from '@/graphql/2014/common/choiceTypes'
 import { resolveLanguageChoice, resolveProficiencyChoice } from '@/graphql/2014/utils/resolvers'
 import { buildSortPipeline } from '@/graphql/common/args'
@@ -12,7 +11,6 @@ import { buildMongoQueryFromNumberFilter } from '@/graphql/common/inputs'
 import { resolveMultipleReferences, resolveSingleReference } from '@/graphql/utils/resolvers'
 import AbilityScoreModel, { AbilityScore } from '@/models/2014/abilityScore'
 import LanguageModel, { Language } from '@/models/2014/language'
-import ProficiencyModel, { Proficiency } from '@/models/2014/proficiency'
 import RaceModel, { Race, RaceAbilityBonus } from '@/models/2014/race'
 import SubraceModel, { Subrace } from '@/models/2014/subrace'
 import TraitModel, { Trait } from '@/models/2014/trait'

--- a/src/graphql/2014/resolvers/race/resolver.ts
+++ b/src/graphql/2014/resolvers/race/resolver.ts
@@ -93,11 +93,6 @@ export class RaceResolver {
     return resolveMultipleReferences(race.languages, LanguageModel)
   }
 
-  @FieldResolver(() => [Proficiency], { nullable: true })
-  async starting_proficiencies(@Root() race: Race): Promise<Proficiency[]> {
-    return resolveMultipleReferences(race.starting_proficiencies, ProficiencyModel)
-  }
-
   @FieldResolver(() => [Subrace], { nullable: true })
   async subraces(@Root() race: Race): Promise<Subrace[]> {
     return resolveMultipleReferences(race.subraces, SubraceModel)
@@ -111,11 +106,6 @@ export class RaceResolver {
   @FieldResolver(() => LanguageChoice, { nullable: true })
   async language_options(@Root() race: Race): Promise<LanguageChoice | null> {
     return resolveLanguageChoice(race.language_options as Choice)
-  }
-
-  @FieldResolver(() => ProficiencyChoice, { nullable: true })
-  async starting_proficiency_options(@Root() race: Race): Promise<ProficiencyChoice | null> {
-    return resolveProficiencyChoice(race.starting_proficiency_options)
   }
 
   @FieldResolver(() => AbilityScoreBonusChoice, { nullable: true })

--- a/src/graphql/2014/resolvers/subrace/resolver.ts
+++ b/src/graphql/2014/resolvers/subrace/resolver.ts
@@ -65,11 +65,6 @@ export class SubraceResolver {
     return resolveSingleReference(subrace.race, RaceModel)
   }
 
-  @FieldResolver(() => [Language], { nullable: true })
-  async languages(@Root() subrace: Subrace): Promise<Language[]> {
-    return resolveMultipleReferences(subrace.languages, LanguageModel)
-  }
-
   @FieldResolver(() => [Trait], { nullable: true })
   async racial_traits(@Root() subrace: Subrace): Promise<Trait[]> {
     return resolveMultipleReferences(subrace.racial_traits, TraitModel)

--- a/src/graphql/2014/resolvers/subrace/resolver.ts
+++ b/src/graphql/2014/resolvers/subrace/resolver.ts
@@ -74,16 +74,6 @@ export class SubraceResolver {
   async racial_traits(@Root() subrace: Subrace): Promise<Trait[]> {
     return resolveMultipleReferences(subrace.racial_traits, TraitModel)
   }
-
-  @FieldResolver(() => [Proficiency], { nullable: true })
-  async starting_proficiencies(@Root() subrace: Subrace): Promise<Proficiency[]> {
-    return resolveMultipleReferences(subrace.starting_proficiencies, ProficiencyModel)
-  }
-
-  @FieldResolver(() => LanguageChoice, { nullable: true })
-  async language_options(@Root() subrace: Subrace): Promise<LanguageChoice | null> {
-    return resolveLanguageChoice(subrace.language_options as Choice)
-  }
 }
 @Resolver(SubraceAbilityBonus)
 export class SubraceAbilityBonusResolver {

--- a/src/graphql/2014/resolvers/subrace/resolver.ts
+++ b/src/graphql/2014/resolvers/subrace/resolver.ts
@@ -1,16 +1,11 @@
 import { Arg, Args, FieldResolver, Query, Resolver, Root } from 'type-graphql'
 
-import { LanguageChoice } from '@/graphql/2014/common/choiceTypes'
-import { resolveLanguageChoice } from '@/graphql/2014/utils/resolvers'
 import { buildSortPipeline } from '@/graphql/common/args'
 import { resolveMultipleReferences, resolveSingleReference } from '@/graphql/utils/resolvers'
 import AbilityScoreModel, { AbilityScore } from '@/models/2014/abilityScore'
-import LanguageModel, { Language } from '@/models/2014/language'
-import ProficiencyModel, { Proficiency } from '@/models/2014/proficiency'
 import RaceModel, { Race } from '@/models/2014/race'
 import SubraceModel, { Subrace, SubraceAbilityBonus } from '@/models/2014/subrace'
 import TraitModel, { Trait } from '@/models/2014/trait'
-import { Choice } from '@/models/common/choice'
 import { escapeRegExp } from '@/util'
 
 import {

--- a/src/models/2014/race.ts
+++ b/src/models/2014/race.ts
@@ -8,7 +8,6 @@ import { srdModelOptions } from '@/util/modelOptions'
 
 import { AbilityScore } from './abilityScore'
 import { Language } from './language'
-import { Proficiency } from './proficiency'
 import { Subrace } from './subrace'
 import { Trait } from './trait'
 
@@ -79,17 +78,6 @@ export class Race {
   @Field(() => Int, { description: 'Base walking speed in feet' })
   @prop({ required: true, index: true, type: () => Number })
   public speed!: number
-
-  @Field(() => [Proficiency], {
-    nullable: true,
-    description: 'Proficiencies granted by this race at start.'
-  })
-  @prop({ type: () => [APIReference] })
-  public starting_proficiencies?: APIReference[]
-
-  // Handled by RaceResolver
-  @prop({ type: () => Choice })
-  public starting_proficiency_options?: Choice
 
   @Field(() => [Subrace], { nullable: true, description: 'Subraces available for this race.' })
   @prop({ type: () => [APIReference] })

--- a/src/models/2014/subrace.ts
+++ b/src/models/2014/subrace.ts
@@ -2,14 +2,10 @@ import { getModelForClass, prop } from '@typegoose/typegoose'
 import { DocumentType } from '@typegoose/typegoose/lib/types'
 import { Field, Int, ObjectType } from 'type-graphql'
 
-import { LanguageChoice } from '@/graphql/2014/common/choiceTypes'
 import { APIReference } from '@/models/common/apiReference'
-import { Choice } from '@/models/common/choice'
 import { srdModelOptions } from '@/util/modelOptions'
 
 import { AbilityScore } from './abilityScore'
-import { Language } from './language'
-import { Proficiency } from './proficiency'
 import { Race } from './race'
 import { Trait } from './trait'
 

--- a/src/models/2014/subrace.ts
+++ b/src/models/2014/subrace.ts
@@ -44,13 +44,6 @@ export class Subrace {
   @prop({ required: true, index: true, type: () => String })
   public index!: string
 
-  @Field(() => [Language], {
-    nullable: true,
-    description: 'Additional languages granted by this subrace.'
-  })
-  @prop({ type: () => [APIReference] })
-  public languages?: APIReference[]
-
   @Field(() => String, { description: 'The name of the subrace (e.g., High Elf).' })
   @prop({ required: true, index: true, type: () => String })
   public name!: string

--- a/src/models/2014/subrace.ts
+++ b/src/models/2014/subrace.ts
@@ -51,13 +51,6 @@ export class Subrace {
   @prop({ type: () => [APIReference] })
   public languages?: APIReference[]
 
-  @Field(() => LanguageChoice, {
-    nullable: true,
-    description: 'Languages typically spoken by this subrace.'
-  })
-  @prop({ type: () => Choice })
-  public language_options?: Choice
-
   @Field(() => String, { description: 'The name of the subrace (e.g., High Elf).' })
   @prop({ required: true, index: true, type: () => String })
   public name!: string
@@ -72,13 +65,6 @@ export class Subrace {
   })
   @prop({ type: () => [APIReference] })
   public racial_traits!: APIReference[]
-
-  @Field(() => [Proficiency], {
-    nullable: true,
-    description: 'Proficiencies granted by this subrace.'
-  })
-  @prop({ type: () => [APIReference] })
-  public starting_proficiencies?: APIReference[]
 
   @prop({ required: true, index: true, type: () => String })
   public url!: string

--- a/src/swagger/paths/2014/races.yml
+++ b/src/swagger/paths/2014/races.yml
@@ -48,10 +48,6 @@ race-path:
                 Elves range from under 5 to over 6 feet tall and have slender builds.
                 Your size is Medium.
               speed: 30
-              starting_proficiencies:
-                - index: skill-perception
-                  name: 'Skill: Perception'
-                  url: '/api/2014/proficiencies/skill-perception'
               subraces:
                 - index: high-elf
                   name: High Elf

--- a/src/swagger/paths/2014/subraces.yml
+++ b/src/swagger/paths/2014/subraces.yml
@@ -25,7 +25,6 @@ subraces-path:
                     url: '/api/2014/ability-scores/wis'
                   bonus: 1
               desc: As a hill dwarf, you have keen senses, deep intuition, and remarkable resilience.
-              languages: []
               race:
                 index: dwarf
                 name: Dwarf

--- a/src/swagger/paths/2014/subraces.yml
+++ b/src/swagger/paths/2014/subraces.yml
@@ -34,7 +34,6 @@ subraces-path:
                 - index: dwarven-toughness
                   name: Dwarven Toughness
                   url: '/api/2014/traits/dwarven-toughness'
-              starting_proficiencies: []
 
 # /api/2014/subraces/{index}/proficiencies
 subrace-proficiencies-path:

--- a/src/swagger/schemas/2014/races.yml
+++ b/src/swagger/schemas/2014/races.yml
@@ -24,14 +24,6 @@ allOf:
       size_description:
         description: 'Flavor description of height and weight for this race.'
         type: string
-      starting_proficiencies:
-        description: 'Starting proficiencies for all new characters of this race.'
-        type: array
-        items:
-          $ref: './combined.yml#/APIReference'
-      starting_proficiency_options:
-        description: 'Starting proficiency options for all new characters of this race.'
-        $ref: './combined.yml#/Choice'
       languages:
         description: 'Starting languages for all new characters of this race.'
         type: array

--- a/src/swagger/schemas/2014/subrace.yml
+++ b/src/swagger/schemas/2014/subrace.yml
@@ -16,11 +16,6 @@ allOf:
         type: array
         items:
           $ref: './combined.yml#/AbilityBonus'
-      languages:
-        description: 'Starting languages for all new characters of the subrace.'
-        type: array
-        items:
-          $ref: './combined.yml#/APIReference'
       racial_traits:
         description: 'List of traits that for the subrace.'
         type: array

--- a/src/swagger/schemas/2014/subrace.yml
+++ b/src/swagger/schemas/2014/subrace.yml
@@ -16,19 +16,11 @@ allOf:
         type: array
         items:
           $ref: './combined.yml#/AbilityBonus'
-      starting_proficiencies:
-        description: 'Starting proficiencies for all new characters of the subrace.'
-        type: array
-        items:
-          $ref: './combined.yml#/APIReference'
       languages:
         description: 'Starting languages for all new characters of the subrace.'
         type: array
         items:
           $ref: './combined.yml#/APIReference'
-      language_options:
-        description: 'Starting languages to choose from for the subrace.'
-        $ref: './combined.yml#/Choice'
       racial_traits:
         description: 'List of traits that for the subrace.'
         type: array

--- a/src/tests/factories/2014/race.factory.ts
+++ b/src/tests/factories/2014/race.factory.ts
@@ -28,16 +28,6 @@ export const raceFactory = Factory.define<Race>(({ sequence, associations, trans
     age: faker.lorem.paragraph(),
     size: faker.helpers.arrayElement(['Small', 'Medium', 'Large']),
     size_description: faker.lorem.paragraph(),
-    starting_proficiencies:
-      associations.starting_proficiencies ??
-      apiReferenceFactory.buildList(
-        faker.number.int({ min: 0, max: 4 }),
-        {},
-        { transient: { resourceType: 'proficiencies' } }
-      ),
-    starting_proficiency_options:
-      associations.starting_proficiency_options ??
-      (faker.datatype.boolean() ? choiceFactory.build() : undefined),
     languages:
       associations.languages ??
       apiReferenceFactory.buildList(

--- a/src/tests/factories/2014/subrace.factory.ts
+++ b/src/tests/factories/2014/subrace.factory.ts
@@ -25,13 +25,6 @@ export const subraceFactory = Factory.define<Subrace>(
         apiReferenceFactory.build({}, { transient: { resourceType: 'races' } }),
       desc: faker.lorem.paragraph(),
       ability_bonuses: subraceAbilityBonusFactory.buildList(faker.number.int({ min: 1, max: 2 })),
-      languages:
-        associations.languages ??
-        apiReferenceFactory.buildList(
-          faker.number.int({ min: 0, max: 1 }),
-          {},
-          { transient: { resourceType: 'languages' } }
-        ),
       racial_traits:
         associations.racial_traits ??
         apiReferenceFactory.buildList(

--- a/src/tests/factories/2014/subrace.factory.ts
+++ b/src/tests/factories/2014/subrace.factory.ts
@@ -25,13 +25,6 @@ export const subraceFactory = Factory.define<Subrace>(
         apiReferenceFactory.build({}, { transient: { resourceType: 'races' } }),
       desc: faker.lorem.paragraph(),
       ability_bonuses: subraceAbilityBonusFactory.buildList(faker.number.int({ min: 1, max: 2 })),
-      starting_proficiencies:
-        associations.starting_proficiencies ??
-        apiReferenceFactory.buildList(
-          faker.number.int({ min: 0, max: 3 }),
-          {},
-          { transient: { resourceType: 'proficiencies' } }
-        ),
       languages:
         associations.languages ??
         apiReferenceFactory.buildList(
@@ -39,9 +32,6 @@ export const subraceFactory = Factory.define<Subrace>(
           {},
           { transient: { resourceType: 'languages' } }
         ),
-      language_options:
-        associations.language_options ??
-        (faker.datatype.boolean() ? choiceFactory.build() : undefined),
       racial_traits:
         associations.racial_traits ??
         apiReferenceFactory.buildList(

--- a/src/tests/factories/2014/subrace.factory.ts
+++ b/src/tests/factories/2014/subrace.factory.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { Factory } from 'fishery'
 
-import { apiReferenceFactory, choiceFactory } from './common.factory'
+import { apiReferenceFactory } from './common.factory'
 
 import type { Subrace, SubraceAbilityBonus } from '@/models/2014/subrace'
 


### PR DESCRIPTION
## What does this do?

BREAKING CHANGE: dropped the `race.starting_proficiencies`, `race.starting_proficiency_options`, `subrace.starting_proficiencies`, `subrace.language_options`, and `subrace.languages` properties of all races and subraces in the database. Clients can instead find this data on the corresponding traits linked to each race or subrace.

## How was it tested?

I ran the database + API project locally with Docker and called the endpoints of the various classes and subclasses. I also ran the unit and integration tests in the API project.

## Is there a Github issue this is resolving?

https://github.com/5e-bits/5e-database/issues/874

## Was any impacted documentation updated to reflect this change?

I touched every reference of the properties in the API project. I took a look at the docs project, but couldn't fully find my way around the project to give a clear indication on if anything needed to change.

## Here's a fun image for your troubles
My players once sold an iron pot to well known business woman and secret member of the Zhentarim and convinced her that it was a magic pot that can restore spoiled food. They even sneaked into her house to cast purify food and drink on it to make sure she believed them.
![Iron Pot](https://github.com/user-attachments/assets/506e3b32-4093-42fd-8fa0-f8fd95bb85cb)

