### PR TITLE
fix: missing subclass features

### DIFF
--- a/src/graphql/2014/resolvers/subclass/resolver.ts
+++ b/src/graphql/2014/resolvers/subclass/resolver.ts
@@ -66,7 +66,7 @@ export class SubclassResolver {
   async subclass_levels(@Root() subclass: Subclass): Promise<Level[]> {
     if (!subclass.index) return []
 
-    return LevelModel.find({ 'subclass.index': subclass.index }).sort({ level: 1 })
+    return LevelModel.find({ 'subclass.index': subclass.index }).sort({ level: 1 }).lean()
   }
 }
 


### PR DESCRIPTION
This PR updates the subclass_levels resolver to use `lean()` in it's MongoDB `find` call, like all of the other `find` calls.

## What does this do?

Subclass specific feature information was not being returned via the GraphQL resolver as the MongoDB results were not passed through `lean()` like all other MongoDB results.

## How was it tested?

Tested using a local install of the repo using Apollo GraphQL Explorer.
<img width="1916" height="915" alt="image" src="https://github.com/user-attachments/assets/aa270bf3-4256-4883-a41c-0bf42d5281e1" />

## Is there a Github issue this is resolving?

This PR resolves #863.

## Was any impacted documentation updated to reflect this change?

No; the documentation (aka GraphQL schema) reflects the function state of the Subclass Resolver, so it could be considered that this PR makes the functionality match the GraphQL Schema, and thus the "documentation" will be MORE accurate after merging.

## Here's a fun image for your troubles

Guess what my D&D players are going to run into soon?
<img width="692" height="974" alt="image" src="https://github.com/user-attachments/assets/da4c4e28-5702-4d30-b2b3-1de91132bb27" />
