### PR TITLE
fix: Add Spell field resolver to Subclass Resolver

### DIFF
--- a/src/graphql/2014/resolvers/subclass/resolver.ts
+++ b/src/graphql/2014/resolvers/subclass/resolver.ts
@@ -6,6 +6,7 @@ import { resolveSingleReference } from '@/graphql/utils/resolvers'
 import ClassModel, { Class } from '@/models/2014/class'
 import FeatureModel, { Feature } from '@/models/2014/feature'
 import LevelModel, { Level } from '@/models/2014/level'
+import SpellModel, { Spell } from '@/models/2014/spell'
 import SubclassModel, { Subclass, SubclassSpell } from '@/models/2014/subclass'
 import { escapeRegExp } from '@/util'
 
@@ -102,5 +103,15 @@ export class SubclassSpellResolver {
     }
 
     return resolvedPrereqs.length > 0 ? resolvedPrereqs : null
+  }
+
+  @FieldResolver(() => Spell, {
+    description: 'The spell gained.',
+    nullable: false
+  })
+  async spell(
+    @Root() subclassSpell: SubclassSpell
+  ): Promise<Spell | null> {
+    return SpellModel.findOne({ 'index': subclassSpell.spell.index }).lean()
   }
 }


### PR DESCRIPTION
## What does this do?

This PR adds a Spell field resolver to the Subclass resolver.

## How was it tested?

On a local install using Apollo GraphQL Explorer.
<img width="1915" height="907" alt="image" src="https://github.com/user-attachments/assets/f52a798f-0136-4a44-9447-cf5cea281980" />

## Is there a Github issue this is resolving?

No, but this does resolve a Discord bug report - https://discord.com/channels/656547667601653787/1445846547471401124
All credit to fergcb, this PR would have been much more difficult with their input.

## Was any impacted documentation updated to reflect this change?

This change makes the returned data match the advertised GraphQL schema, so arguably the Schema "documentation" will be more accurate after this PR is applied.

## Here's a fun image for your troubles

I created a template that allowed me to churn out Baldur's Mouth newspapers for the *Descent into Avernus* players. This was one of the earlier editions:
<img width="813" height="1050" alt="u3SojJb" src="https://github.com/user-attachments/assets/653bbf0d-ff24-41bf-aa08-e491fb2ae954" />

