### PR TITLE
docs: specify damage level map value types in spell schema

### DIFF
--- a/src/swagger/schemas/2014/spell.yml
+++ b/src/swagger/schemas/2014/spell.yml
@@ -66,21 +66,25 @@ spell-model:
             $ref: './combined.yml#/APIReference'
 damage-at-character-level-model:
   description: |
-    'Spell Damage'
+    'Spell Damage scaling by character level'
   type: object
   properties:
     damage_at_character_level:
+      description: 'Damage at each character level, keyed by level number.'
       type: object
-      additionalProperties: true
+      additionalProperties:
+        type: string
     damage_type:
       $ref: './combined.yml#/APIReference'
 damage-at-slot-level-model:
   description: |
-    'Spell Damage'
+    'Spell Damage scaling by spell slot level'
   type: object
   properties:
     damage_at_slot_level:
+      description: 'Damage at each spell slot level, keyed by slot level number.'
       type: object
-      additionalProperties: true
+      additionalProperties:
+        type: string
     damage_type:
       $ref: './combined.yml#/APIReference'


### PR DESCRIPTION
## Summary

- Changes `additionalProperties: true` to `additionalProperties: { type: string }` for both `damage_at_character_level` and `damage_at_slot_level`
- Adds descriptions to clarify the difference between character-level and slot-level damage scaling
- Values are damage dice strings like `"2d6"` or `"3d8"`, not arbitrary types

Closes #289

## Test plan

- [ ] Swagger UI shows `string` as the value type for damage level maps instead of `any`
- [ ] API responses still validate against the updated schema