### PR TITLE
fix(equipment-categories): Link equipmentCategories to MagicItems

### DIFF
--- a/src/graphql/2024/common/unions.ts
+++ b/src/graphql/2024/common/unions.ts
@@ -1,5 +1,6 @@
 import { createUnionType } from 'type-graphql'
 
+import { MagicItem2024 } from '@/models/2024/magicItem'
 import { APIReference } from '@/models/common/apiReference'
 
 import { Ammunition, AdventuringGear, Armor, Pack, Weapon, Tool } from './equipmentTypes'
@@ -68,6 +69,26 @@ export const AnyEquipment = createUnionType({
     }
 
     console.warn('Could not resolve type for AnyEquipment:', value)
+    return AdventuringGear
+  }
+})
+
+export const AnyEquipmentOrMagicItem = createUnionType({
+  name: 'AnyEquipmentOrMagicItem',
+  types: () => {
+    return [Weapon, AdventuringGear, Ammunition, Armor, Pack, Tool, MagicItem2024] as const
+  },
+  resolveType: (value) => {
+    if ('rarity' in value) {
+      return MagicItem2024
+    }
+
+    const equipmentType = resolveEquipmentType(value)
+    if (equipmentType) {
+      return equipmentType
+    }
+
+    console.warn('Could not resolve type for AnyEquipmentOrMagicItem:', value)
     return AdventuringGear
   }
 })

--- a/src/graphql/2024/resolvers/equipmentCategory/resolver.ts
+++ b/src/graphql/2024/resolvers/equipmentCategory/resolver.ts
@@ -1,9 +1,10 @@
 import { Args, FieldResolver, Query, Resolver, Root } from 'type-graphql'
 
-import { AnyEquipment } from '@/graphql/2024/common/unions'
+import { AnyEquipmentOrMagicItem } from '@/graphql/2024/common/unions'
 import { buildSortPipeline } from '@/graphql/common/args'
 import EquipmentModel, { Equipment2024 } from '@/models/2024/equipment'
 import EquipmentCategoryModel, { EquipmentCategory2024 } from '@/models/2024/equipmentCategory'
+import MagicItemModel, { MagicItem2024 } from '@/models/2024/magicItem'
 import { escapeRegExp } from '@/util'
 
 import {
@@ -61,37 +62,21 @@ export class EquipmentCategoryResolver {
     return EquipmentCategoryModel.findOne({ index }).lean()
   }
 
-  // TODO: Remove when Magic Items are added
-  @FieldResolver(() => [AnyEquipment])
-  async equipment(@Root() equipmentCategory: EquipmentCategory2024): Promise<Equipment2024[]> {
+  @FieldResolver(() => [AnyEquipmentOrMagicItem])
+  async equipment(
+    @Root() equipmentCategory: EquipmentCategory2024
+  ): Promise<(Equipment2024 | MagicItem2024)[]> {
     if (equipmentCategory.equipment.length === 0) {
       return []
     }
 
     const equipmentIndices = equipmentCategory.equipment.map((ref) => ref.index)
 
-    const equipments = await EquipmentModel.find({ index: { $in: equipmentIndices } }).lean()
+    const [equipments, magicItems] = await Promise.all([
+      EquipmentModel.find({ index: { $in: equipmentIndices } }).lean(),
+      MagicItemModel.find({ index: { $in: equipmentIndices } }).lean()
+    ])
 
-    return equipments
+    return [...equipments, ...magicItems]
   }
-
-  // TODO: Add Magic Items
-  // @FieldResolver(() => [EquipmentOrMagicItem])
-  // async equipment(
-  //   @Root() equipmentCategory: EquipmentCategory
-  // ): Promise<(Equipment | MagicItem)[]> {
-  //   if (equipmentCategory.equipment.length === 0) {
-  //     return []
-  //   }
-
-  //   const equipmentIndices = equipmentCategory.equipment.map((ref) => ref.index)
-
-  //   // Fetch both Equipment and MagicItems matching the indices
-  //   const [equipments, magicItems] = await Promise.all([
-  //     EquipmentModel.find({ index: { $in: equipmentIndices } }).lean(),
-  //     MagicItemModel.find({ index: { $in: equipmentIndices } }).lean()
-  //   ])
-
-  //   return [...equipments, ...magicItems]
-  // }
 }


### PR DESCRIPTION
## What does this do?

Links 2024 equipment categories to magic items

## Here's a fun image for your troubles

<img width="640" height="960" alt="image" src="https://github.com/user-attachments/assets/84a24ba7-5dc1-483e-954c-b226b6b63eaf" />

