### PR TITLE
fix(all): Fixes all changes that came up with db moving to strict mode

### DIFF
--- a/src/graphql/2024/common/choiceTypes.ts
+++ b/src/graphql/2024/common/choiceTypes.ts
@@ -43,6 +43,45 @@ export class ScorePrerequisiteChoice2024 {
   from!: ScorePrerequisiteOptionSet2024
 }
 
+// --- Ability Score Choice Types (for PrimaryAbility2024.ability_score_options) ---
+
+@ObjectType({ description: 'A reference to a 2024 ability score within a choice option set.' })
+export class AbilityScoreChoiceOption2024 {
+  @Field(() => String, { description: 'The type of this option.' })
+  option_type!: string
+
+  @Field(() => AbilityScore2024, { description: 'The resolved AbilityScore2024 object.' })
+  item!: AbilityScore2024
+}
+
+@ObjectType({ description: 'The set of ability score options for a primary ability choice.' })
+export class AbilityScoreChoiceOptionSet2024 {
+  @Field(() => String, { description: 'The type of the option set.' })
+  option_set_type!: string
+
+  @Field(() => [AbilityScoreChoiceOption2024], {
+    description: 'The available ability score options.'
+  })
+  options!: AbilityScoreChoiceOption2024[]
+}
+
+@ObjectType({ description: 'An ability score choice for a 2024 class primary ability.' })
+export class AbilityScoreChoice2024 {
+  @Field(() => String, { nullable: true, description: 'Description of the choice.' })
+  desc?: string
+
+  @Field(() => Int, { description: 'Number of ability scores to choose.' })
+  choose!: number
+
+  @Field(() => String, { description: 'The type of choice.' })
+  type!: string
+
+  @Field(() => AbilityScoreChoiceOptionSet2024, {
+    description: 'The set of ability score options.'
+  })
+  from!: AbilityScoreChoiceOptionSet2024
+}
+
 // --- Proficiency Choice Types (for Background2024.proficiency_choices) ---
 
 @ObjectType({ description: 'A reference to a 2024 proficiency within a choice option set.' })

--- a/src/graphql/2024/resolvers/class/resolver.ts
+++ b/src/graphql/2024/resolvers/class/resolver.ts
@@ -1,5 +1,7 @@
 import { Args, FieldResolver, Query, Resolver, Root } from 'type-graphql'
 
+import { AbilityScoreChoice2024 } from '@/graphql/2024/common/choiceTypes'
+import { resolveAbilityScoreChoice2024 } from '@/graphql/2024/utils/choiceResolvers'
 import { buildSortPipeline } from '@/graphql/common/args'
 import { resolveMultipleReferences, resolveSingleReference } from '@/graphql/utils/resolvers'
 import AbilityScoreModel, { AbilityScore2024 } from '@/models/2024/abilityScore'
@@ -110,7 +112,14 @@ export class MultiClassingPrereq2024Resolver {
 @Resolver(PrimaryAbility2024)
 export class PrimaryAbility2024Resolver {
   @FieldResolver(() => [AbilityScore2024], { nullable: true })
-  async all_of(@Root() primaryAbility: PrimaryAbility2024): Promise<AbilityScore2024[]> {
-    return resolveMultipleReferences(primaryAbility.all_of, AbilityScoreModel)
+  async ability_scores(@Root() primaryAbility: PrimaryAbility2024): Promise<AbilityScore2024[]> {
+    return resolveMultipleReferences(primaryAbility.ability_scores, AbilityScoreModel)
+  }
+
+  @FieldResolver(() => AbilityScoreChoice2024, { nullable: true })
+  async ability_score_options(
+    @Root() primaryAbility: PrimaryAbility2024
+  ): Promise<AbilityScoreChoice2024 | null> {
+    return resolveAbilityScoreChoice2024(primaryAbility.ability_score_options)
   }
 }

--- a/src/graphql/2024/resolvers/equipment/resolver.ts
+++ b/src/graphql/2024/resolvers/equipment/resolver.ts
@@ -78,6 +78,12 @@ export class EquipmentResolver {
     if (!equipment.properties) return null
     return resolveMultipleReferences(equipment.properties, WeaponPropertyModel)
   }
+
+  @FieldResolver(() => Equipment2024, { nullable: true })
+  async storage(@Root() equipment: Equipment2024): Promise<Equipment2024 | null> {
+    if (!equipment.storage) return null
+    return resolveSingleReference(equipment.storage, EquipmentModel)
+  }
 }
 
 @Resolver(Content)

--- a/src/graphql/2024/utils/choiceResolvers.ts
+++ b/src/graphql/2024/utils/choiceResolvers.ts
@@ -1,4 +1,7 @@
 import {
+  AbilityScoreChoice2024,
+  AbilityScoreChoiceOption2024,
+  AbilityScoreChoiceOptionSet2024,
   Proficiency2024Choice,
   Proficiency2024ChoiceOption,
   Proficiency2024ChoiceOptionSet,
@@ -74,6 +77,36 @@ export async function resolveProficiency2024Choice(
       option_set_type: optionsArraySet.option_set_type,
       options: resolvedOptions
     } as Proficiency2024ChoiceOptionSet
+  }
+}
+
+export async function resolveAbilityScoreChoice2024(
+  choiceData: Choice | undefined
+): Promise<AbilityScoreChoice2024 | null> {
+  if (!choiceData) return null
+
+  const optionsArraySet = choiceData.from as OptionsArrayOptionSet
+  const resolvedOptions: AbilityScoreChoiceOption2024[] = []
+
+  for (const dbOption of optionsArraySet.options) {
+    const dbRefOpt = dbOption as ReferenceOption
+    const abilityScore = await resolveSingleReference(dbRefOpt.item, AbilityScoreModel)
+    if (abilityScore !== null) {
+      resolvedOptions.push({
+        option_type: dbRefOpt.option_type,
+        item: abilityScore as AbilityScore2024
+      })
+    }
+  }
+
+  return {
+    desc: choiceData.desc,
+    choose: choiceData.choose,
+    type: choiceData.type,
+    from: {
+      option_set_type: optionsArraySet.option_set_type,
+      options: resolvedOptions
+    } as AbilityScoreChoiceOptionSet2024
   }
 }
 

--- a/src/models/2014/monster.ts
+++ b/src/models/2014/monster.ts
@@ -472,6 +472,10 @@ export class Monster {
   @prop({ type: () => [String] })
   public damage_vulnerabilities!: string[]
 
+  @Field(() => String)
+  @prop({ type: () => String })
+  public desc?: string
+
   @Field(() => Int)
   @prop({ required: true, index: true, type: () => Number })
   public dexterity!: number

--- a/src/models/2024/class.ts
+++ b/src/models/2024/class.ts
@@ -80,10 +80,10 @@ export class PrimaryAbility2024 {
     description: 'All of these ability scores must meet the minimum.'
   })
   @prop({ type: () => [APIReference] })
-  public all_of?: APIReference[]
+  public ability_scores?: APIReference[]
 
   @prop({ type: () => Choice })
-  public any_of?: Choice
+  public ability_score_options?: Choice
 }
 
 @ObjectType({ description: 'A character class in D&D 5e 2024.' })

--- a/src/models/2024/equipment.ts
+++ b/src/models/2024/equipment.ts
@@ -112,6 +112,13 @@ export class Equipment2024 {
   @prop({ type: () => [Content] })
   public contents?: Content[]
 
+  @Field(() => Equipment2024, {
+    nullable: true,
+    description: 'The equipment this item is contained in.'
+  })
+  @prop({ type: () => APIReference })
+  public storage?: APIReference
+
   @Field(() => Cost, { description: 'Cost of the equipment in coinage.' })
   @prop({ type: () => Cost })
   public cost!: Cost


### PR DESCRIPTION
## What does this do?

- **`PrimaryAbility2024` field renames** — `all_of` → `ability_scores`, `any_of` → `ability_score_options` for clearer naming
- **`ability_score_options` GraphQL resolver** — New `AbilityScoreChoice2024` types (`choiceTypes.ts`) and `resolveAbilityScoreChoice2024` resolver function, exposing the primary ability choice field in the 2024 GraphQL schema
- **`Equipment2024.storage` GraphQL resolver** — Resolves the `storage` `APIReference` to the actual `Equipment2024` document
- **`Monster.desc` field** — Adds the optional `desc` field to the 2014 Monster model (part of the strict mode fix commit)
