### PR TITLE
feat: redesign homepage to match docs site

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,208 +1,514 @@
-/* Reset and base styles */
-* {
+/* Import fonts — match docs site */
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Young+Serif&display=swap");
+
+/* Reset */
+*,
+*::before,
+*::after {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
+/* ─── Theme tokens (matching docs site) ─── */
+
 :root {
-  --primary-color: #d81921;
-  --primary-dark: #c62828;
-  --text-color: #263238;
-  --bg-dark: #21201e;
-  --bg-light: #f5f5f5;
-  --link-color: #1b95e0;
-  --spacing: 1rem;
+  --dnd-accent: #e53935;
+  --dnd-accent-dark: #d32f2f;
+  --dnd-accent-darker: #c62828;
+  --dnd-accent-darkest: #b71c1c;
+  --dnd-bg: #101010;
+  --dnd-surface: #141414;
+  --dnd-surface-2: #1a1a1a;
+  --dnd-border: #262626;
+  --dnd-text: #ffffff;
+  --dnd-text-secondary: rgba(255, 255, 255, 0.7);
+  --dnd-text-tertiary: rgba(255, 255, 255, 0.6);
+  --font-body: "Inter", system-ui, -apple-system, sans-serif;
+  --font-display: "Young Serif", serif;
+  --font-mono: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
+  --radius: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 8px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --dnd-accent: #e53935;
+    --dnd-bg: #ffffff;
+    --dnd-surface: #f8f9fa;
+    --dnd-surface-2: #f1f3f5;
+    --dnd-border: #e9ecef;
+    --dnd-text: #212529;
+    --dnd-text-secondary: #495057;
+    --dnd-text-tertiary: #5c6370;
+  }
+}
+
+/* ─── Base ─── */
+
+html {
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body {
-  font-family: 'Helvetica', sans-serif;
-  color: var(--text-color);
+  font-family: var(--font-body);
+  color: var(--dnd-text);
+  background-color: var(--dnd-bg);
   line-height: 1.6;
-  padding-top: 3.5rem;
 }
 
-/* Typography */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  margin: 0 0 var(--spacing) 0;
-  font-weight: 900;
+::selection {
+  color: var(--dnd-text);
+  background: var(--dnd-accent-darkest);
 }
 
 a {
-  color: var(--link-color);
+  color: var(--dnd-accent);
   text-decoration: none;
 }
 
-/* Navigation */
+a:hover {
+  text-decoration: underline;
+  text-decoration-color: var(--dnd-accent);
+}
+
+/* ─── Noise texture overlay ─── */
+
+.noise {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+  background-size: 128px;
+  background-repeat: repeat;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  opacity: 0.04;
+  mix-blend-mode: screen;
+}
+
+@media (prefers-color-scheme: light) {
+  .noise {
+    opacity: 0.08;
+  }
+}
+
+/* ─── Navbar ─── */
+
 .navbar {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  background: var(--primary-color);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--dnd-bg);
   z-index: 1000;
   height: 3.5rem;
-  overflow: hidden;
 }
 
 .nav-container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 var(--spacing);
+  padding: 0 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  height: 100%;
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--dnd-text);
+  text-decoration: none;
+}
+
+.nav-brand:hover {
+  text-decoration: none;
+  color: var(--dnd-text);
 }
 
 .nav-links {
   display: flex;
-  justify-content: flex-end;
   list-style: none;
+  gap: 0;
+  align-items: center;
 }
 
 .nav-links li a {
-  display: block;
-  padding: 1rem;
-  color: white;
-  transition: background-color 0.3s;
-}
-
-.nav-links li.active a,
-.nav-links li a:hover {
-  background-color: var(--primary-dark);
-}
-
-/* Header */
-.header {
-  background-color: var(--bg-dark);
-  padding: 4rem 1rem;
-  text-align: center;
-}
-
-.header h1 {
-  color: white;
-  margin: 0 auto;
-  max-width: 800px;
-  font-size: 3.5rem;
-  line-height: 1.2;
-}
-
-.header h2 {
-  color: white;
-  margin: 0.5rem auto 0;
-  max-width: 800px;
-  font-weight: 300;
-  font-size: 1.5rem;
-  opacity: 0.9;
-}
-
-/* CTA Section */
-.cta {
-  background-color: var(--bg-light);
-  padding: 3rem 1rem;
-  text-align: center;
-  font-size: 1.3rem;
-  font-weight: 300;
-}
-
-/* Interactive Section */
-.content {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem var(--spacing);
-}
-
-.interactive-section {
-  max-width: 800px;
-  margin: 0 auto;
-}
-
-.api-input {
   display: flex;
-  margin: 1rem 0;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  overflow: hidden;
-}
-
-.api-prefix {
-  padding: 0.5rem 1rem;
-  background: var(--bg-light);
-  border-right: 1px solid #ddd;
-  white-space: nowrap;
-}
-
-#interactive {
-  flex: 1;
+  align-items: center;
   padding: 0.5rem;
-  border: none;
-  outline: none;
+  color: var(--dnd-text-tertiary);
+  border-radius: var(--radius-md);
+  transition: color 0.15s ease;
+  text-decoration: none;
 }
 
-.api-input button {
-  padding: 0.5rem 1.5rem;
-  background: var(--link-color);
-  color: white;
-  border: none;
+.nav-links li a:hover {
+  color: var(--dnd-text);
+  text-decoration: none;
+}
+
+/* ─── Hero section ─── */
+
+.hero {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 4rem 1rem;
+  padding-top: 7rem;
+  position: relative;
+}
+
+.hero__title {
+  font-family: var(--font-display);
+  font-size: 3.5rem;
+  color: var(--dnd-accent-darkest);
+  letter-spacing: -0.02em;
+  margin-bottom: 0.5rem;
+  line-height: 1.15;
+  filter: drop-shadow(0 0 5px rgba(183, 28, 28, 0.5))
+    drop-shadow(0 0 15px rgba(198, 40, 40, 0.25))
+    drop-shadow(0 0 25px rgba(198, 40, 40, 0.1));
+}
+
+@media (prefers-color-scheme: light) {
+  .hero__title {
+    filter: none;
+  }
+}
+
+.hero__subtitle {
+  font-size: 1.25rem;
+  color: var(--dnd-text);
+  margin-bottom: 1.5rem;
+  font-weight: 400;
+}
+
+.hero__buttons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 0;
+}
+
+/* Glassmorphism buttons matching docs */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  background-color: rgba(229, 57, 53, 0.04);
+  border: 1px solid rgba(229, 57, 53, 0.3);
+  padding: 0.3rem 0.5rem;
+  color: var(--dnd-accent);
+  border-radius: var(--radius);
+  backdrop-filter: blur(4px);
+  transition: all 0.2s ease;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.3s;
+  text-decoration: none;
 }
 
-.api-input button:hover {
-  background-color: #1576b3;
+.btn:hover {
+  background-color: rgba(229, 57, 53, 0.1);
+  border-color: rgba(229, 57, 53, 0.5);
+  text-shadow: 0 0 10px rgba(229, 57, 53, 0.5);
+  text-decoration: none;
+  color: var(--dnd-accent);
 }
 
-.hints {
-  font-size: 0.9rem;
-  margin: 1rem 0;
+/* ─── API Example (matching docs ApiExample component) ─── */
+
+.api-example {
+  margin: 2rem auto 1rem;
+  padding: 0 1.5rem;
+  width: 575px;
+  max-width: 100%;
+  text-align: left;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease-out, transform 0.3s ease-out;
 }
 
-.output {
-  background: var(--bg-light);
+.api-example.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.api-url {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 1.5rem 0.5rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.url-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.url-row code {
+  background: none;
+  border: none;
+  color: var(--dnd-text);
+  opacity: 0.5;
+  font-size: 0.85rem;
+}
+
+.api-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.selector-btn {
+  padding: 0 0.25rem;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--dnd-text-tertiary);
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 400;
+  height: 16px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  user-select: none;
+  transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.selector-btn:hover {
+  color: var(--dnd-text-secondary);
+}
+
+.selector-btn.selected {
+  border-color: var(--dnd-border);
+  background-color: var(--dnd-surface-2);
+  color: var(--dnd-text);
+}
+
+.try-btn {
+  background-color: var(--dnd-accent);
+  color: #fff;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.2s ease;
+  flex-shrink: 0;
+}
+
+.try-btn:hover {
+  opacity: 0.9;
+  background-color: var(--dnd-accent-darker);
+}
+
+.try-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Code output block */
+.code-block {
+  background-color: var(--dnd-surface);
+  border: 1px solid var(--dnd-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  height: 350px;
+  margin-top: 1rem;
+  position: relative;
+}
+
+.code-block .json-output,
+.code-block .loading-state {
+  animation: fadeIn 0.15s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.json-output {
   padding: 1rem;
-  border-radius: 4px;
+  margin: 0;
   overflow: auto;
-  max-height: 400px;
+  font-size: 0.85rem;
+  font-family: var(--font-mono);
+  color: var(--dnd-text);
+  height: 350px;
+  line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-/* Responsive Design */
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 350px;
+  color: var(--dnd-text-tertiary);
+  background-color: var(--dnd-surface);
+  font-size: 0.8125rem;
+}
+
+.loading-dot {
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--dnd-text-tertiary);
+  margin: 0 2px;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.loading-dot:nth-child(2) { animation-delay: 0.2s; }
+.loading-dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes pulse {
+  0%, 80%, 100% { opacity: 0.2; }
+  40% { opacity: 1; }
+}
+
+/* ─── Footer ─── */
+
+.footer {
+  background-color: var(--dnd-bg);
+  border-top: 1px solid var(--dnd-border);
+  padding: 3rem 1rem;
+  text-align: center;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.footer-links a {
+  color: var(--dnd-text-secondary);
+  font-size: 0.875rem;
+  transition: color 0.2s ease;
+  text-decoration: none;
+}
+
+.footer-links a:hover {
+  color: var(--dnd-accent);
+  text-decoration: none;
+}
+
+.footer-copyright {
+  margin-top: 1.5rem;
+  color: var(--dnd-text-tertiary);
+  font-size: 0.8125rem;
+}
+
+/* ─── Responsive ─── */
+
 @media (max-width: 768px) {
   .nav-links {
     display: none;
   }
 
   .menu-toggle {
-    display: block;
+    display: flex;
   }
 
-  .api-input {
+  .hero {
+    padding: 3rem 1rem;
+    padding-top: 6rem;
+    min-height: 100vh;
+  }
+
+  .hero__title {
+    font-size: 2.5rem;
+  }
+
+  .hero__subtitle {
+    font-size: 1rem;
+  }
+
+  .api-example {
+    padding: 0 0.5rem;
+  }
+
+  .api-url {
+    font-size: 0.75rem;
+    padding: 0.35rem 0.5rem;
+  }
+
+  .json-output {
+    font-size: 0.75rem;
+    max-height: 300px;
+    padding: 0.75rem;
+  }
+
+  .footer-inner {
     flex-direction: column;
-  }
-
-  .api-prefix {
-    border-right: none;
-    border-bottom: 1px solid #ddd;
+    gap: 2rem;
   }
 }
 
+/* Hamburger menu */
 .menu-toggle {
   display: none;
   background: none;
-  border: none;
-  padding: 1rem;
+  border: 1px solid var(--dnd-border);
+  padding: 0.4rem;
   cursor: pointer;
+  border-radius: var(--radius);
+  flex-direction: column;
+  gap: 3px;
+  align-items: center;
+  justify-content: center;
 }
 
 .menu-toggle span {
   display: block;
-  width: 25px;
-  height: 3px;
-  background: white;
-  margin: 4px 0;
-  transition: 0.3s;
+  width: 16px;
+  height: 2px;
+  background: var(--dnd-text-secondary);
+  transition: 0.2s ease;
+}
+
+/* Mobile nav open state */
+.nav-links.open {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 3.5rem;
+  left: 0;
+  right: 0;
+  background: var(--dnd-bg);
+  border-bottom: 1px solid var(--dnd-border);
+  padding: 0.5rem 1rem;
+}
+
+.nav-links.open li a {
+  padding: 0.75rem 0.5rem;
 }

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -9,6 +9,7 @@
     <meta name="description" content="REST API to access D&D 5th Edition SRD database" />
     <meta name="keywords" content="Dungeons, Dragons, 5th, Edition, API, SRD" />
     <meta name="theme-color" content="#D81921" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
@@ -32,102 +33,135 @@
   </head>
 
   <body>
+    <!-- Noise overlay -->
+    <div class="noise"></div>
+
     <!-- Navbar -->
     <nav class="navbar">
       <div class="nav-container">
-        <button class="menu-toggle" aria-label="Toggle menu">
+        <button class="menu-toggle" aria-label="Toggle menu" onclick="toggleMenu()">
           <span></span>
           <span></span>
           <span></span>
         </button>
-        <ul class="nav-links">
-          <li class="active"><a href="/">Home</a></li>
-          <li><a href="https://5e-bits.github.io/docs">Documentation</a></li>
-          <li><a href="https://discord.gg/TQuYTv7">Chat</a></li>
-          <li><a href="https://github.com/bagelbits/5e-srd-api">Contribute</a></li>
+        <ul class="nav-links" id="navLinks">
+          <li><a href="https://discord.gg/TQuYTv7" aria-label="Discord"><svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg></a></li>
+          <li><a href="https://github.com/5e-bits/5e-srd-api" aria-label="GitHub"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg></a></li>
         </ul>
       </div>
     </nav>
 
-    <!-- Main Content -->
-    <section id="home">
-      <div class="header">
-        <h1>D&D 5e API</h1>
-        <h2>The 5th Edition Dungeons and Dragons API</h2>
-      </div>
+    <!-- Hero -->
+    <section class="hero">
+      <div>
+        <h1 class="hero__title">D&D 5e SRD API</h1>
+        <p class="hero__subtitle">The 5th Edition Dungeons &amp; Dragons SRD API</p>
+        <div class="hero__buttons">
+          <a class="btn" href="https://5e-bits.github.io/docs/tutorials">Tutorials</a>
+          <a class="btn" href="https://5e-bits.github.io/docs/api">API Reference</a>
+        </div>
 
-      <div class="cta">
-        <p>
-          Just a simple api for things within the Official 5th Edition SRD<br />
-          and easily accessible through a modern RESTful API.
-        </p>
-        <p>Enjoy the D&D 5th Edition API!</p>
-      </div>
-
-      <div class="content">
-        <div class="interactive-section">
-          <h1>Try it now!</h1>
-          <div class="api-input">
-            <span class="api-prefix">https://www.dnd5eapi.co/api/2014/</span>
-            <input id="interactive" type="text" placeholder="spells/acid-arrow/" />
-            <button onclick="interactiveCall();return false;">submit</button>
+        <!-- API Example -->
+        <div class="api-example visible" id="apiExample">
+          <div class="api-url">
+            <code id="endpointDisplay">/api/2014/monsters/owlbear</code>
+            <div class="api-selector" role="tablist" aria-label="API content type selector">
+              <button role="tab" aria-selected="true" class="selector-btn selected" onclick="selectType('monster', this)">monster</button>
+              <button role="tab" aria-selected="false" class="selector-btn" onclick="selectType('spell', this)">spell</button>
+              <button role="tab" aria-selected="false" class="selector-btn" onclick="selectType('class', this)">class</button>
+              <button role="tab" aria-selected="false" class="selector-btn" onclick="selectType('race', this)">race</button>
+              <button role="tab" aria-selected="false" class="selector-btn" onclick="selectType('item', this)">item</button>
+              <button role="tab" aria-selected="false" class="selector-btn" onclick="selectType('feat', this)">feat</button>
+            </div>
           </div>
-
-          <div class="hints">
-            Need a hint? try
-            <a href="#" onClick="update('classes/');return false;">classes/</a>,
-            <a href="#" onClick="update('features/');return false;">features/</a>,
-            <a href="#" onClick="update('monsters/adult-black-dragon/');return false;"
-              >monsters/adult-black-dragon/</a
-            >
-            or
-            <a href="#" onClick="update('spells/?name=Acid+Arrow');return false;"
-              >spells/?name=Acid+Arrow</a
-            >
+          <div class="code-block" id="codeBlock">
+            <pre class="json-output" id="jsonOutput"></pre>
           </div>
-
-          <p class="result-label">Resource for <span id="interactive_name">Acid Arrow</span></p>
-          <pre id="interactive_output" class="output"></pre>
         </div>
       </div>
     </section>
 
-    <!-- Replace old scripts with modern JS -->
+    <!-- Footer -->
+    <footer class="footer">
+      <div class="footer-links">
+        <a href="https://5e-bits.github.io/docs">Documentation</a>
+        <a href="https://discord.gg/TQuYTv7">Discord</a>
+        <a href="https://github.com/5e-bits/5e-srd-api">GitHub</a>
+        <a href="https://github.com/5e-bits/5e-srd-api/issues">Issues</a>
+      </div>
+      <p class="footer-copyright">Copyright &copy; <script>document.write(new Date().getFullYear())</script> 5e-bits contributors. Built with the SRD.</p>
+    </footer>
+
     <script>
-      // Update input field and trigger API call
-      function update(call) {
-        document.getElementById('interactive').value = call
-        interactiveCall()
+      // ─── API Example ───
+      const apiBase = 'https://www.dnd5eapi.co'
+      const endpoints = {
+        monster: '/api/2014/monsters/owlbear',
+        spell: '/api/2014/spells/fire-bolt',
+        class: '/api/2014/classes/wizard',
+        race: '/api/2014/races/elf',
+        item: '/api/2014/equipment/crossbow-heavy',
+        feat: '/api/2014/feats/grappler',
       }
 
-      // Make API call and update the output
-      async function interactiveCall() {
-        const input = document.getElementById('interactive')
-        const nameSpan = document.getElementById('interactive_name')
-        const output = document.getElementById('interactive_output')
+      let currentType = 'monster'
+      let cachedResponses = {}
 
-        let content = input.value
-        if (!content) {
-          content = 'spells/acid-arrow/'
+      function selectType(type, btn) {
+        currentType = type
+        document.getElementById('endpointDisplay').textContent = endpoints[type]
+
+        document.querySelectorAll('.selector-btn').forEach(b => {
+          b.classList.remove('selected')
+          b.setAttribute('aria-selected', 'false')
+        })
+        btn.classList.add('selected')
+        btn.setAttribute('aria-selected', 'true')
+
+        fetchData()
+      }
+
+      function showResult(text) {
+        const codeBlock = document.getElementById('codeBlock')
+        codeBlock.innerHTML = '<pre class="json-output">' + escapeHtml(text) + '</pre>'
+      }
+
+      function showLoading() {
+        const codeBlock = document.getElementById('codeBlock')
+        codeBlock.innerHTML = '<div class="loading-state"><span class="loading-dot"></span><span class="loading-dot"></span><span class="loading-dot"></span></div>'
+      }
+
+      function escapeHtml(str) {
+        return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+      }
+
+      async function fetchData() {
+        if (cachedResponses[currentType]) {
+          showResult(JSON.stringify(cachedResponses[currentType], null, 2))
+          return
         }
+
+        showLoading()
 
         try {
-          const response = await fetch('api/' + content)
-
-          if (response.ok) {
-            const data = await response.json()
-            nameSpan.textContent = data.name ? `${data.name}:` : 'this request:'
-            output.textContent = JSON.stringify(data, null, 2)
-          } else {
-            output.textContent = `${response.status} ${response.statusText}`
-          }
+          const response = await fetch(apiBase + endpoints[currentType])
+          if (!response.ok) throw new Error('HTTP ' + response.status)
+          const data = await response.json()
+          cachedResponses[currentType] = data
+          showResult(JSON.stringify(data, null, 2))
         } catch (err) {
-          output.textContent = 'Error: ' + err.message
+          showResult('Error: ' + err.message)
         }
       }
 
-      // Initialize with default data
-      document.addEventListener('DOMContentLoaded', interactiveCall)
+      // Auto-fetch on page load
+      document.addEventListener('DOMContentLoaded', fetchData)
+
+
+      // ─── Mobile menu ───
+      function toggleMenu() {
+        document.getElementById('navLinks').classList.toggle('open')
+      }
     </script>
 
     <!-- Google Analytics -->

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -57,6 +57,7 @@
         <h1 class="hero__title">D&D 5e SRD API</h1>
         <p class="hero__subtitle">The 5th Edition Dungeons &amp; Dragons SRD API</p>
         <div class="hero__buttons">
+          <a class="btn" href="https://5e-bits.github.io/docs/introduction">Introduction</a>
           <a class="btn" href="https://5e-bits.github.io/docs/tutorials">Tutorials</a>
           <a class="btn" href="https://5e-bits.github.io/docs/api">API Reference</a>
         </div>


### PR DESCRIPTION
## Summary
- Redesign the API homepage to align with the docs site design language (Inter/Young Serif typography, dark-first theme, red accent palette, noise texture, glassmorphism buttons)
- Replace old interactive input with a tabbed API explorer that auto-fetches across six resource types (monster, spell, class, race, item, feat) with cached responses
- Add `prefers-color-scheme` support for automatic light/dark theming
- Simplify navbar to Discord/GitHub icons and footer to centered links
<img width="1156" height="990" alt="image" src="https://github.com/user-attachments/assets/db802a95-cc9e-4737-854f-dedf0c7ac74e" />

<img width="1156" height="990" alt="image" src="https://github.com/user-attachments/assets/c8e6e1bd-b121-4736-b914-110f5aae0b8c" />



## Test plan
- [ ] Verify homepage renders correctly in dark mode (default)
- [ ] Verify homepage renders correctly in light mode (browser preference)
- [ ] Test all six API explorer tabs return data and cache correctly
- [ ] Verify responsive layout on mobile viewports
- [ ] Check Tutorials and API Reference buttons link to correct docs pages
- [ ] Verify Discord and GitHub icon links work in navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)