### PR TITLE
refactor: homepage hero redesign with rotating endpoint previews

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -343,13 +343,14 @@ a:hover {
   transform: translateY(8px);
 }
 
-/* JSON preview — Notion-ish code block. All snippets are 8 lines so
-   the slot height stays uniform without needing min-height. */
+/* JSON preview — Notion-ish code block. All snippets are 9 lines, but
+   we also pin a min-height so any drift won't reflow the page. */
 .preview {
   margin: 0 auto;
   padding: 0.9rem 1rem;
   max-width: 30rem;
   width: 100%;
+  min-height: calc(9 * 1.55em + 1.8rem);
   font-family: var(--font-mono);
   font-size: 0.82rem;
   line-height: 1.55;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -20,10 +20,12 @@
   --dnd-bg: #101010;
   --dnd-surface: #141414;
   --dnd-surface-2: #1a1a1a;
+  --dnd-surface-3: #1f1f1f;
   --dnd-border: #262626;
+  --dnd-border-strong: #333333;
   --dnd-text: #ffffff;
-  --dnd-text-secondary: rgba(255, 255, 255, 0.7);
-  --dnd-text-tertiary: rgba(255, 255, 255, 0.6);
+  --dnd-text-secondary: rgba(255, 255, 255, 0.78);
+  --dnd-text-tertiary: rgba(255, 255, 255, 0.55);
   --font-body: "Inter", system-ui, -apple-system, sans-serif;
   --font-display: "Young Serif", serif;
   --font-mono: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
@@ -38,10 +40,12 @@
     --dnd-bg: #ffffff;
     --dnd-surface: #f8f9fa;
     --dnd-surface-2: #f1f3f5;
-    --dnd-border: #e9ecef;
+    --dnd-surface-3: #e9ecef;
+    --dnd-border: #e0e3e7;
+    --dnd-border-strong: #c8ced3;
     --dnd-text: #212529;
-    --dnd-text-secondary: #495057;
-    --dnd-text-tertiary: #5c6370;
+    --dnd-text-secondary: rgba(33, 37, 41, 0.85);
+    --dnd-text-tertiary: rgba(33, 37, 41, 0.6);
   }
 }
 
@@ -93,9 +97,7 @@ a:hover {
 }
 
 @media (prefers-color-scheme: light) {
-  .noise {
-    opacity: 0.08;
-  }
+  .noise { opacity: 0.08; }
 }
 
 /* ─── Navbar ─── */
@@ -113,51 +115,54 @@ a:hover {
 .nav-container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 1.25rem;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
   height: 100%;
 }
 
 .nav-brand {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-weight: 600;
-  font-size: 1rem;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
   color: var(--dnd-text);
   text-decoration: none;
+  letter-spacing: 0.01em;
+  display: inline-flex;
+  align-items: baseline;
+  line-height: 1;
 }
 
-.nav-brand:hover {
-  text-decoration: none;
-  color: var(--dnd-text);
-}
+.nav-brand:hover { text-decoration: none; color: var(--dnd-text); }
+.nav-brand span { color: var(--dnd-accent); margin-left: 0.1rem; }
 
 .nav-links {
   display: flex;
   list-style: none;
-  gap: 0;
+  gap: 0.25rem;
   align-items: center;
 }
 
 .nav-links li a {
   display: flex;
   align-items: center;
-  padding: 0.5rem;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
   color: var(--dnd-text-tertiary);
   border-radius: var(--radius-md);
-  transition: color 0.15s ease;
+  transition: color 0.15s ease, background-color 0.15s ease;
   text-decoration: none;
 }
 
 .nav-links li a:hover {
   color: var(--dnd-text);
+  background-color: var(--dnd-surface);
   text-decoration: none;
 }
 
-/* ─── Hero section ─── */
+/* ─── Hero ─── */
 
 .hero {
   min-height: 100vh;
@@ -166,34 +171,43 @@ a:hover {
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 4rem 1rem;
-  padding-top: 7rem;
+  padding: 4rem 1rem 3rem;
+  padding-top: 5.5rem;
   position: relative;
+}
+
+.hero__inner {
+  width: 100%;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .hero__title {
   font-family: var(--font-display);
-  font-size: 3.5rem;
+  font-size: clamp(2.25rem, 6vw + 1rem, 4rem);
   color: var(--dnd-accent-darkest);
   letter-spacing: -0.02em;
   margin-bottom: 0.5rem;
-  line-height: 1.15;
-  filter: drop-shadow(0 0 5px rgba(183, 28, 28, 0.5))
+  line-height: 1.1;
+  filter:
+    drop-shadow(0 0 5px rgba(183, 28, 28, 0.5))
     drop-shadow(0 0 15px rgba(198, 40, 40, 0.25))
     drop-shadow(0 0 25px rgba(198, 40, 40, 0.1));
 }
 
 @media (prefers-color-scheme: light) {
-  .hero__title {
-    filter: none;
-  }
+  .hero__title { filter: none; }
 }
 
 .hero__subtitle {
-  font-size: 1.25rem;
-  color: var(--dnd-text);
+  font-size: 1.05rem;
+  color: var(--dnd-text-secondary);
   margin-bottom: 1.5rem;
   font-weight: 400;
+  max-width: 32rem;
+  line-height: 1.5;
 }
 
 .hero__buttons {
@@ -201,208 +215,227 @@ a:hover {
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 0;
+  gap: 0.75rem;
 }
 
-/* Glassmorphism buttons matching docs */
+/* Buttons — ghost + primary */
 .btn {
   display: inline-flex;
   align-items: center;
+  gap: 0.4rem;
   background-color: rgba(229, 57, 53, 0.04);
   border: 1px solid rgba(229, 57, 53, 0.3);
-  padding: 0.3rem 0.5rem;
+  padding: 0.55rem 0.9rem;
   color: var(--dnd-accent);
   border-radius: var(--radius);
   backdrop-filter: blur(4px);
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
   font-family: var(--font-body);
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
   text-decoration: none;
+  line-height: 1;
 }
 
 .btn:hover {
   background-color: rgba(229, 57, 53, 0.1);
   border-color: rgba(229, 57, 53, 0.5);
-  text-shadow: 0 0 10px rgba(229, 57, 53, 0.5);
   text-decoration: none;
   color: var(--dnd-accent);
 }
 
-/* ─── API Example (matching docs ApiExample component) ─── */
-
-.api-example {
-  margin: 2rem auto 1rem;
-  padding: 0 1.5rem;
-  width: 575px;
-  max-width: 100%;
-  text-align: left;
-  opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.3s ease-out, transform 0.3s ease-out;
+.btn--primary {
+  background-color: var(--dnd-accent);
+  border-color: var(--dnd-accent);
+  color: #fff;
 }
 
-.api-example.visible {
-  opacity: 1;
-  transform: translateY(0);
+.btn--primary:hover {
+  background-color: var(--dnd-accent-darker);
+  border-color: var(--dnd-accent-darker);
+  color: #fff;
 }
 
-.api-url {
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  padding: 1.5rem 0.5rem 0.5rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.url-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-}
-
-.url-row code {
-  background: none;
-  border: none;
-  color: var(--dnd-text);
-  opacity: 0.5;
-  font-size: 0.85rem;
-}
-
-.api-url > code {
-  max-width: 100%;
-  overflow-wrap: anywhere;
-  word-break: break-all;
-  text-align: center;
-}
-
-.api-selector {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-
-.selector-btn {
-  padding: 0 0.25rem;
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--dnd-text-tertiary);
-  border-radius: var(--radius);
-  cursor: pointer;
-  font-size: 0.75rem;
-  font-weight: 400;
-  height: 16px;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  font-family: var(--font-mono);
-  user-select: none;
-  transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
-}
-
-.selector-btn:hover {
+.btn--ghost {
+  background-color: transparent;
+  border-color: var(--dnd-border-strong);
   color: var(--dnd-text-secondary);
 }
 
-.selector-btn.selected {
-  border-color: var(--dnd-border);
-  background-color: var(--dnd-surface-2);
+.btn--ghost:hover {
+  background-color: var(--dnd-surface);
+  border-color: var(--dnd-border-strong);
   color: var(--dnd-text);
 }
 
-.try-btn {
-  background-color: var(--dnd-accent);
-  color: #fff;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: none;
-  border-radius: 50%;
-  cursor: pointer;
+/* ─── Build {a bestiary | a spellbook | …} — title + endpoints ─── */
+
+.headline {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 1.6vw + 0.6rem, 1.75rem);
+  color: var(--dnd-text);
+  letter-spacing: -0.015em;
+  line-height: 1.15;
+  font-weight: 100;
+  margin: 6rem 0 1.25rem;
+  text-align: center;
+}
+
+/* Both "Build" and the phrase live inside this container — they fade together. */
+.headline__line {
+  display: inline-block;
+  opacity: 1;
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+  -webkit-transition: opacity 0.52s ease, -webkit-transform 0.52s ease;
+  transition: opacity 0.52s ease, transform 0.52s ease;
+  -webkit-animation: cardIn 0.85s ease 0.05s backwards;
+  animation: cardIn 0.85s ease 0.05s backwards;
+}
+
+.headline__line.is-out {
+  opacity: 0;
+  -webkit-transform: translateY(8px);
+  transform: translateY(8px);
+}
+
+.headline__build { /* default white from .headline */ }
+
+.headline__phrase {
+  color: var(--dnd-accent);
+}
+
+@-webkit-keyframes cardIn {
+  from { opacity: 0; -webkit-transform: translateY(8px); }
+}
+
+@keyframes cardIn {
+  from { opacity: 0; transform: translateY(8px); }
+}
+
+/* Endpoints — the offering. Centered list of GET routes. */
+.endpoints {
+  list-style: none;
+  margin: 0 auto;
+  padding: 0.55rem 1rem 0.65rem;
   display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  align-items: start;
+  width: 100%;
+  max-width: 30rem;
+  background-color: rgba(255, 255, 255, 0.015);
+  border: 1px solid var(--dnd-border);
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  opacity: 1;
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+  -webkit-transition: opacity 0.52s ease, -webkit-transform 0.52s ease;
+  transition: opacity 0.52s ease, transform 0.52s ease;
+  -webkit-animation: cardIn 0.85s ease 0.18s backwards;
+  animation: cardIn 0.85s ease 0.18s backwards;
+}
+
+.endpoints.is-out {
+  opacity: 0;
+  -webkit-transform: translateY(8px);
+  transform: translateY(8px);
+}
+
+/* JSON preview — Notion-ish code block. All snippets are 8 lines so
+   the slot height stays uniform without needing min-height. */
+.preview {
+  margin: 0 auto;
+  padding: 0.9rem 1rem;
+  max-width: 30rem;
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.55;
+  color: var(--dnd-text-secondary);
+  background-color: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--dnd-border);
+  border-bottom: none;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  text-align: left;
+  white-space: pre;
+  overflow-x: auto;
+  opacity: 1;
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+  -webkit-transition: opacity 0.52s ease, -webkit-transform 0.52s ease;
+  transition: opacity 0.52s ease, transform 0.52s ease;
+  -webkit-animation: cardIn 0.85s ease 0.28s backwards;
+  animation: cardIn 0.85s ease 0.28s backwards;
+}
+
+.preview.is-out {
+  opacity: 0;
+  -webkit-transform: translateY(8px);
+  transform: translateY(8px);
+}
+
+/* Token colors — muted, Notion-ish */
+.preview .t-key { color: #c792ea; }
+.preview .t-string { color: #a8d6a0; }
+.preview .t-number { color: #f0a070; }
+.preview .t-comment { color: rgba(255, 255, 255, 0.35); font-style: italic; }
+
+@media (prefers-color-scheme: light) {
+  .preview {
+    background-color: var(--dnd-surface);
+    color: var(--dnd-text-secondary);
+  }
+  .endpoints {
+    background-color: var(--dnd-surface-2);
+  }
+  .preview .t-key { color: #8839ef; }
+  .preview .t-string { color: #40a02b; }
+  .preview .t-number { color: #fe640b; }
+  .preview .t-comment { color: rgba(33, 37, 41, 0.5); }
+}
+
+.endpoint {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  transition: opacity 0.2s ease;
+  gap: 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--dnd-text-secondary);
+  text-decoration: none;
+  letter-spacing: -0.005em;
+  -webkit-transition: color 0.2s ease;
+  transition: color 0.2s ease;
+}
+
+.endpoint__verb {
+  font-family: var(--font-body);
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  color: var(--dnd-accent);
+  font-weight: 600;
+  background-color: rgba(229, 57, 53, 0.08);
+  padding: 0.2rem 0.45rem;
+  border-radius: 3px;
+  line-height: 1;
   flex-shrink: 0;
 }
 
-.try-btn:hover {
-  opacity: 0.9;
-  background-color: var(--dnd-accent-darker);
-}
-
-.try-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-/* Code output block */
-.code-block {
-  background-color: var(--dnd-surface);
-  border: 1px solid var(--dnd-border);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  height: 350px;
-  margin-top: 1rem;
-  position: relative;
-}
-
-.code-block .json-output,
-.code-block .loading-state {
-  animation: fadeIn 0.15s ease;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-.json-output {
-  padding: 1rem;
-  margin: 0;
-  overflow: auto;
-  font-size: 0.85rem;
-  font-family: var(--font-mono);
+.endpoint:hover {
   color: var(--dnd-text);
-  height: 350px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
+  text-decoration: none;
 }
 
-.loading-state {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 350px;
-  color: var(--dnd-text-tertiary);
-  background-color: var(--dnd-surface);
-  font-size: 0.8125rem;
-}
-
-.loading-dot {
-  display: inline-block;
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background: var(--dnd-text-tertiary);
-  margin: 0 2px;
-  animation: pulse 1.2s ease-in-out infinite;
-}
-
-.loading-dot:nth-child(2) { animation-delay: 0.2s; }
-.loading-dot:nth-child(3) { animation-delay: 0.4s; }
-
-@keyframes pulse {
-  0%, 80%, 100% { opacity: 0.2; }
-  40% { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .headline__line, .endpoints, .preview {
+    -webkit-transition: none;
+    transition: none;
+    -webkit-transform: none;
+    transform: none;
+    -webkit-animation: none;
+    animation: none;
+  }
 }
 
 /* ─── Footer ─── */
@@ -410,7 +443,7 @@ a:hover {
 .footer {
   background-color: var(--dnd-bg);
   border-top: 1px solid var(--dnd-border);
-  padding: 3rem 1rem;
+  padding: 2.5rem 1rem;
   text-align: center;
 }
 
@@ -434,7 +467,7 @@ a:hover {
 }
 
 .footer-copyright {
-  margin-top: 1.5rem;
+  margin-top: 1.25rem;
   color: var(--dnd-text-tertiary);
   font-size: 0.8125rem;
 }
@@ -442,125 +475,26 @@ a:hover {
 /* ─── Responsive ─── */
 
 @media (max-width: 768px) {
-  .nav-links {
-    display: none;
-  }
-
-  .menu-toggle {
-    display: flex;
-  }
-
   .hero {
-    padding: 3rem 1rem;
-    padding-top: 6rem;
-    min-height: 100vh;
-    min-height: 100svh;
+    padding: 2rem 1rem 2.5rem;
+    padding-top: 5rem;
   }
-
-  .hero__title {
-    font-size: 2.5rem;
-  }
-
   .hero__subtitle {
-    font-size: 1rem;
+    font-size: 0.95rem;
+    margin-bottom: 1.5rem;
   }
-
-  .api-example {
-    padding: 0 0.5rem;
-  }
-
-  .api-url {
-    font-size: 0.75rem;
-    padding: 0.35rem 0.5rem;
-  }
-
-  .json-output {
-    font-size: 0.75rem;
-    max-height: 300px;
-    padding: 0.75rem;
-  }
-
-  .code-block {
-    height: 300px;
-  }
-
-  .loading-state {
-    height: 300px;
-  }
-
-  .selector-btn {
-    height: 2.75rem;
-    padding: 0 0.75rem;
-    font-size: 0.8125rem;
-  }
-
-  .footer-inner {
-    flex-direction: column;
-    gap: 2rem;
-  }
+  .headline { margin: 5rem 0 1rem; }
+  .preview { font-size: 0.78rem; padding: 0.7rem 0.9rem; }
+  .endpoints { padding: 0.5rem 0.9rem 0.6rem; }
+  .endpoint { font-size: 0.78rem; }
 }
 
 @media (max-width: 480px) {
-  .hero__title {
-    font-size: 2rem;
-  }
-
   .hero__buttons .btn {
     font-size: 0.8125rem;
-    padding: 0.35rem 0.6rem;
+    padding: 0.5rem 0.75rem;
   }
-
-  .api-selector {
-    gap: 0.5rem;
-  }
-
-  .api-url {
-    font-size: 0.7rem;
-  }
-
-  .code-block,
-  .json-output,
-  .loading-state {
-    height: 260px;
-    max-height: 260px;
-  }
-}
-
-/* Hamburger menu */
-.menu-toggle {
-  display: none;
-  background: none;
-  border: 1px solid var(--dnd-border);
-  padding: 0.4rem;
-  cursor: pointer;
-  border-radius: var(--radius);
-  flex-direction: column;
-  gap: 3px;
-  align-items: center;
-  justify-content: center;
-}
-
-.menu-toggle span {
-  display: block;
-  width: 16px;
-  height: 2px;
-  background: var(--dnd-text-secondary);
-  transition: 0.2s ease;
-}
-
-/* Mobile nav open state */
-.nav-links.open {
-  display: flex;
-  flex-direction: column;
-  position: absolute;
-  top: 3.5rem;
-  left: 0;
-  right: 0;
-  background: var(--dnd-bg);
-  border-bottom: 1px solid var(--dnd-border);
-  padding: 0.5rem 1rem;
-}
-
-.nav-links.open li a {
-  padding: 0.75rem 0.5rem;
+  .headline { margin: 4.5rem 0 1rem; font-size: 1.65rem; }
+  .endpoint { font-size: 0.74rem; }
+  .preview { font-size: 0.74rem; }
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -161,6 +161,7 @@ a:hover {
 
 .hero {
   min-height: 100vh;
+  min-height: 100svh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -199,6 +200,7 @@ a:hover {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
   gap: 1rem;
   margin-bottom: 0;
 }
@@ -272,9 +274,18 @@ a:hover {
   font-size: 0.85rem;
 }
 
+.api-url > code {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+  text-align: center;
+}
+
 .api-selector {
   display: flex;
   align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
   gap: 0.35rem;
 }
 
@@ -443,6 +454,7 @@ a:hover {
     padding: 3rem 1rem;
     padding-top: 6rem;
     min-height: 100vh;
+    min-height: 100svh;
   }
 
   .hero__title {
@@ -468,9 +480,49 @@ a:hover {
     padding: 0.75rem;
   }
 
+  .code-block {
+    height: 300px;
+  }
+
+  .loading-state {
+    height: 300px;
+  }
+
+  .selector-btn {
+    height: 2.75rem;
+    padding: 0 0.75rem;
+    font-size: 0.8125rem;
+  }
+
   .footer-inner {
     flex-direction: column;
     gap: 2rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero__title {
+    font-size: 2rem;
+  }
+
+  .hero__buttons .btn {
+    font-size: 0.8125rem;
+    padding: 0.35rem 0.6rem;
+  }
+
+  .api-selector {
+    gap: 0.5rem;
+  }
+
+  .api-url {
+    font-size: 0.7rem;
+  }
+
+  .code-block,
+  .json-output,
+  .loading-state {
+    height: 260px;
+    max-height: 260px;
   }
 }
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -51,7 +51,7 @@
     <section class="hero">
       <div class="hero__inner">
         <h1 class="hero__title">D&D 5e SRD API</h1>
-        <p class="hero__subtitle">A free and open API for the D&amp;D 5e SRD.</p>
+        <p class="hero__subtitle">The unofficial REST API for the 5e System Reference Document. Free, open, and built by the community.</p>
         <div class="hero__buttons">
           <a class="btn btn--primary" href="https://5e-bits.github.io/docs/introduction">Documentation</a>
           <a class="btn btn--ghost" href="https://github.com/5e-bits/5e-srd-api">Contribute</a>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -51,7 +51,7 @@
     <section class="hero">
       <div class="hero__inner">
         <h1 class="hero__title">D&D 5e SRD API</h1>
-        <p class="hero__subtitle">A free, open REST API for the 5e SRD &mdash; build anything for your campaigns.</p>
+        <p class="hero__subtitle">A free and open API for the D&amp;D 5e System Reference Document.</p>
         <div class="hero__buttons">
           <a class="btn btn--primary" href="https://5e-bits.github.io/docs/introduction">Documentation</a>
           <a class="btn btn--ghost" href="https://github.com/5e-bits/5e-srd-api">Contribute</a>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -131,11 +131,10 @@
   "index": "barbarian",
   "name": "Barbarian",
   "hit_die": 12,
-  "saving_throws": [
-    { "index": "str", "name": "STR" },
-    { "index": "con", "name": "CON" }
-  ],
-  "subclasses": [{ "name": "Berserker" }]
+  "saving_throws": [{ "name": "STR" }, { "name": "CON" }],
+  "subclasses": [{ "name": "Berserker" }],
+  "class_levels": "/api/2014/classes/barbarian/levels",
+  "starting_equipment": [{ "quantity": 4, "equipment": { "name": "Javelin" } }]
 }`,
         },
         {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -39,12 +39,8 @@
     <!-- Navbar -->
     <nav class="navbar">
       <div class="nav-container">
-        <button class="menu-toggle" aria-label="Toggle menu" onclick="toggleMenu()">
-          <span></span>
-          <span></span>
-          <span></span>
-        </button>
-        <ul class="nav-links" id="navLinks">
+        <a class="nav-brand" href="/" aria-label="5e SRD API home">5e<span>API</span></a>
+        <ul class="nav-links">
           <li><a href="https://discord.gg/TQuYTv7" aria-label="Discord"><svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg></a></li>
           <li><a href="https://github.com/5e-bits/5e-srd-api" aria-label="GitHub"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg></a></li>
         </ul>
@@ -53,32 +49,24 @@
 
     <!-- Hero -->
     <section class="hero">
-      <div>
+      <div class="hero__inner">
         <h1 class="hero__title">D&D 5e SRD API</h1>
-        <p class="hero__subtitle">The 5th Edition Dungeons &amp; Dragons SRD API</p>
+        <p class="hero__subtitle">A free, open REST API for the 5e SRD &mdash; build anything for your campaigns.</p>
         <div class="hero__buttons">
-          <a class="btn" href="https://5e-bits.github.io/docs/introduction">Introduction</a>
-          <a class="btn" href="https://5e-bits.github.io/docs/tutorials">Tutorials</a>
-          <a class="btn" href="https://5e-bits.github.io/docs/api">API Reference</a>
+          <a class="btn btn--primary" href="https://5e-bits.github.io/docs/introduction">Documentation</a>
+          <a class="btn btn--ghost" href="https://github.com/5e-bits/5e-srd-api">Contribute</a>
+          <a class="btn btn--ghost" href="https://discord.gg/TQuYTv7">Community</a>
         </div>
 
-        <!-- API Example -->
-        <div class="api-example visible" id="apiExample">
-          <div class="api-url">
-            <code id="endpointDisplay">/api/2014/monsters/owlbear</code>
-            <div class="api-selector" role="tablist" aria-label="API content type selector">
-              <button role="tab" aria-selected="true" class="selector-btn selected" onclick="selectType('monster', this)">monster</button>
-              <button role="tab" aria-selected="false" class="selector-btn" onclick="selectType('spell', this)">spell</button>
-              <button role="tab" aria-selected="false" class="selector-btn" onclick="selectType('class', this)">class</button>
-              <button role="tab" aria-selected="false" class="selector-btn" onclick="selectType('race', this)">race</button>
-              <button role="tab" aria-selected="false" class="selector-btn" onclick="selectType('item', this)">item</button>
-              <button role="tab" aria-selected="false" class="selector-btn" onclick="selectType('feat', this)">feat</button>
-            </div>
-          </div>
-          <div class="code-block" id="codeBlock">
-            <pre class="json-output" id="jsonOutput"></pre>
-          </div>
-        </div>
+        <!-- Build {a bestiary | a spellbook | …} -->
+        <h2 class="headline" aria-live="polite">
+          <span class="headline__line" id="line">
+            <span class="headline__build" id="buildWord">Build</span> <span class="headline__phrase" id="phraseWord">a bestiary</span>
+          </span>
+        </h2>
+
+        <pre class="preview" id="preview" aria-hidden="true"></pre>
+        <ul class="endpoints" id="endpointList"></ul>
       </div>
     </section>
 
@@ -94,75 +82,169 @@
     </footer>
 
     <script>
-      // ─── API Example ───
+      // ─── Rotate through build ideas: phrase + endpoints ───
       const apiBase = 'https://www.dnd5eapi.co'
-      const endpoints = {
-        monster: '/api/2014/monsters/owlbear',
-        spell: '/api/2014/spells/fire-bolt',
-        class: '/api/2014/classes/wizard',
-        race: '/api/2014/races/elf',
-        item: '/api/2014/equipment/crossbow-heavy',
-        feat: '/api/2014/feats/grappler',
+
+      const slides = [
+        {
+          phrase: 'a bestiary',
+          slug: 'owlbear',
+          endpoints: [
+            { label: '/api/2014/monsters' },
+            { label: '/api/2014/monsters/{slug}' },
+          ],
+          preview: `{
+  "index": "owlbear",
+  "name": "Owlbear",
+  "size": "Large",
+  "type": "monstrosity",
+  "hit_points": 59,
+  "armor_class": [{ "type": "natural", "value": 13 }],
+  "challenge_rating": 3
+}`,
+        },
+        {
+          phrase: 'a spellbook',
+          slug: 'fireball',
+          endpoints: [
+            { label: '/api/2014/spells' },
+            { label: '/api/2014/spells/{slug}' },
+          ],
+          preview: `{
+  "index": "fireball",
+  "name": "Fireball",
+  "level": 3,
+  "range": "150 feet",
+  "casting_time": "1 action",
+  "components": ["V", "S", "M"],
+  "school": { "name": "Evocation" }
+}`,
+        },
+        {
+          phrase: 'a character sheet',
+          slug: 'barbarian',
+          endpoints: [
+            { label: '/api/2014/classes' },
+            { label: '/api/2014/classes/{slug}' },
+          ],
+          preview: `{
+  "index": "barbarian",
+  "name": "Barbarian",
+  "hit_die": 12,
+  "saving_throws": [
+    { "index": "str", "name": "STR" },
+    { "index": "con", "name": "CON" }
+  ],
+  "subclasses": [{ "name": "Berserker" }]
+}`,
+        },
+        {
+          phrase: 'a loot ledger',
+          slug: 'longsword',
+          endpoints: [
+            { label: '/api/2014/equipment' },
+            { label: '/api/2014/equipment/{slug}' },
+          ],
+          preview: `{
+  "index": "longsword",
+  "name": "Longsword",
+  "weapon_category": "Martial",
+  "weapon_range": "Melee",
+  "damage": { "damage_dice": "1d8" },
+  "cost": { "quantity": 15, "unit": "gp" },
+  "weight": 3
+}`,
+        },
+      ]
+
+      const $ = (id) => document.getElementById(id)
+
+      // Lightweight JSON-ish syntax highlighter. Handles our limited subset:
+      // string keys, string/number values, and /* … */ comments.
+      function highlight(text) {
+        const escaped = text
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+        return escaped.replace(
+          /(\/\*[^*]*\*\/)|("(?:[^"\\]|\\.)*")(\s*:)?|\b(\d+(?:\.\d+)?)\b/g,
+          (m, comment, str, colon, num) => {
+            if (comment) return `<span class="t-comment">${comment}</span>`
+            if (str) {
+              const cls = colon ? 't-key' : 't-string'
+              return `<span class="${cls}">${str}</span>${colon || ''}`
+            }
+            if (num) return `<span class="t-number">${num}</span>`
+            return m
+          }
+        )
       }
 
-      let currentType = 'monster'
-      let cachedResponses = {}
-
-      function selectType(type, btn) {
-        currentType = type
-        document.getElementById('endpointDisplay').textContent = endpoints[type]
-
-        document.querySelectorAll('.selector-btn').forEach(b => {
-          b.classList.remove('selected')
-          b.setAttribute('aria-selected', 'false')
-        })
-        btn.classList.add('selected')
-        btn.setAttribute('aria-selected', 'true')
-
-        fetchData()
+      function paint(i) {
+        const slide = slides[i]
+        // Re-write both "Build" and the phrase so they fade in together each cycle
+        $('buildWord').textContent = 'Build'
+        $('phraseWord').textContent = slide.phrase
+        $('endpointList').innerHTML = slide.endpoints.map((e) => `
+          <li>
+            <a class="endpoint" href="${apiBase}${e.label.replace('{slug}', slide.slug)}" target="_blank" rel="noopener">
+              <span class="endpoint__verb">GET</span>
+              <span class="endpoint__path">${e.label}</span>
+            </a>
+          </li>
+        `).join('')
+        $('preview').innerHTML = highlight(slide.preview)
       }
 
-      function showResult(text) {
-        const codeBlock = document.getElementById('codeBlock')
-        codeBlock.innerHTML = '<pre class="json-output">' + escapeHtml(text) + '</pre>'
+      // ─── Transition: ease down + fade out, swap, ease up + fade in ───
+
+      let activeIdx = 0
+      let autoTimer = null
+      let paused = false
+      const advanceMs = 6200
+      const fadeMs = 520
+
+      function transition(i) {
+        if (i === activeIdx) return
+        const line = $('line')
+        const ep = $('endpointList')
+        const pv = $('preview')
+        line.classList.add('is-out')
+        ep.classList.add('is-out')
+        pv.classList.add('is-out')
+        window.setTimeout(() => {
+          activeIdx = i
+          paint(i)
+          // Force layout so the next class change reliably triggers a transition (Safari-safe)
+          void line.offsetWidth
+          line.classList.remove('is-out')
+          ep.classList.remove('is-out')
+          pv.classList.remove('is-out')
+        }, fadeMs)
       }
 
-      function showLoading() {
-        const codeBlock = document.getElementById('codeBlock')
-        codeBlock.innerHTML = '<div class="loading-state"><span class="loading-dot"></span><span class="loading-dot"></span><span class="loading-dot"></span></div>'
+      function startAutoplay() {
+        stopAutoplay()
+        autoTimer = window.setInterval(() => {
+          if (paused) return
+          transition((activeIdx + 1) % slides.length)
+        }, advanceMs)
       }
 
-      function escapeHtml(str) {
-        return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+      function stopAutoplay() {
+        if (autoTimer) window.clearInterval(autoTimer)
+        autoTimer = null
       }
 
-      async function fetchData() {
-        if (cachedResponses[currentType]) {
-          showResult(JSON.stringify(cachedResponses[currentType], null, 2))
-          return
+      document.addEventListener('DOMContentLoaded', () => {
+        const heroInner = document.querySelector('.hero__inner')
+        if (heroInner) {
+          heroInner.addEventListener('mouseenter', () => { paused = true })
+          heroInner.addEventListener('mouseleave', () => { paused = false })
         }
-
-        showLoading()
-
-        try {
-          const response = await fetch(apiBase + endpoints[currentType])
-          if (!response.ok) throw new Error('HTTP ' + response.status)
-          const data = await response.json()
-          cachedResponses[currentType] = data
-          showResult(JSON.stringify(data, null, 2))
-        } catch (err) {
-          showResult('Error: ' + err.message)
-        }
-      }
-
-      // Auto-fetch on page load
-      document.addEventListener('DOMContentLoaded', fetchData)
-
-
-      // ─── Mobile menu ───
-      function toggleMenu() {
-        document.getElementById('navLinks').classList.toggle('open')
-      }
+        paint(0)
+        startAutoplay()
+      })
     </script>
 
     <!-- Google Analytics -->

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -51,7 +51,7 @@
     <section class="hero">
       <div class="hero__inner">
         <h1 class="hero__title">D&D 5e SRD API</h1>
-        <p class="hero__subtitle">The unofficial REST API for the 5e System Reference Document. Free, open, and built by the community.</p>
+        <p class="hero__subtitle">The 5e System Reference Document, as a REST API.</p>
         <div class="hero__buttons">
           <a class="btn btn--primary" href="https://5e-bits.github.io/docs/introduction">Documentation</a>
           <a class="btn btn--ghost" href="https://github.com/5e-bits/5e-srd-api">Contribute</a>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -51,7 +51,7 @@
     <section class="hero">
       <div class="hero__inner">
         <h1 class="hero__title">D&D 5e SRD API</h1>
-        <p class="hero__subtitle">A free and open API for the D&amp;D 5e System Reference Document.</p>
+        <p class="hero__subtitle">A free and open API for the D&amp;D 5e SRD.</p>
         <div class="hero__buttons">
           <a class="btn btn--primary" href="https://5e-bits.github.io/docs/introduction">Documentation</a>
           <a class="btn btn--ghost" href="https://github.com/5e-bits/5e-srd-api">Contribute</a>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -50,8 +50,8 @@
     <!-- Hero -->
     <section class="hero">
       <div class="hero__inner">
-        <h1 class="hero__title">D&D 5e API</h1>
-        <p class="hero__subtitle">A free and open API for the D&amp;D 5e System Reference Document.</p>
+        <h1 class="hero__title">D&D 5e SRD API</h1>
+        <p class="hero__subtitle">A free and open API for the D&amp;D 5e SRD.</p>
         <div class="hero__buttons">
           <a class="btn btn--primary" href="https://5e-bits.github.io/docs/introduction">Documentation</a>
           <a class="btn btn--ghost" href="https://github.com/5e-bits/5e-srd-api">Contribute</a>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -50,8 +50,8 @@
     <!-- Hero -->
     <section class="hero">
       <div class="hero__inner">
-        <h1 class="hero__title">D&D 5e SRD API</h1>
-        <p class="hero__subtitle">A free and open API for the D&amp;D 5e SRD.</p>
+        <h1 class="hero__title">D&D 5e API</h1>
+        <p class="hero__subtitle">A free and open API for the D&amp;D 5e System Reference Document.</p>
         <div class="hero__buttons">
           <a class="btn btn--primary" href="https://5e-bits.github.io/docs/introduction">Documentation</a>
           <a class="btn btn--ghost" href="https://github.com/5e-bits/5e-srd-api">Contribute</a>


### PR DESCRIPTION
## Summary
- Replaces the API-type selector + static code panel with a rotating **Build {a bestiary | a spellbook | a character sheet | a loot ledger}** headline that cycles through `monsters`, `spells`, `classes`, and `equipment` endpoints.
- Each slide shows a real, faithful JSON excerpt from `dnd5eapi.co` (verified against live responses) with lightweight syntax highlighting — no fake fields or `/* ... */` placeholders.
- Endpoint list now reads as a **footer attached to the codeblock**: shared border, continuous rounded corner (square top, rounded bottom), and a slightly tinted background.
- Typography rebalanced across the page — codeblock and endpoints share `0.82rem` mono with synchronized step-downs at 768px (`0.78rem`) and 480px (`0.74rem`).
- Adds a `5eAPI` wordmark brand to the navbar, tightens hero spacing, and improves mobile responsiveness via fluid `clamp()` sizing on the title/headline plus `100svh` for mobile URL bars.

## Test plan
- [ ] Verify hero renders correctly at desktop (>1024px), tablet (768px), and mobile (≤480px) widths
- [ ] Confirm slide rotation cycles every ~6.2s with smooth fade transitions, and pauses on hover
- [ ] Spot-check that each preview JSON matches the live API response at `https://www.dnd5eapi.co/api/2014/{monsters|spells|classes|equipment}/{slug}`
- [ ] Verify endpoint footer visually connects to the codeblock (no border seam) in both dark and light color schemes
- [ ] Confirm `prefers-reduced-motion` disables the slide-in animations
- [ ] Tap targets in nav and CTA buttons remain comfortable on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)