### PR TITLE
fix(readme): remove unnecessary HTML entity escaping for ampersand

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Uptime](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F5e-bits%2Fdnd-uptime%2Fmain%2Fapi%2Fwebsite%2Fresponse-time.json)
 ![Uptime](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2F5e-bits%2Fdnd-uptime%2Fmain%2Fapi%2Fwebsite%2Fuptime.json)
 
-REST API to access [D&amp;D 5th Edition SRD API](https://www.dnd5eapi.co/)
+REST API to access [D&D 5th Edition SRD API](https://www.dnd5eapi.co/)
 
 Talk to us [on Discord!](https://discord.gg/TQuYTv7)
 


### PR DESCRIPTION
## Summary

- Tiny no-op fix to test whether a `fix:` conventional commit triggers a release-please patch bump (the prior `refactor:` PR did not).
- Replaces `D&amp;D` with `D&D` in the README — both render identically, but the HTML entity isn't needed in markdown body text.

## Test plan

- [ ] Confirm release-please opens / updates a release PR with a patch bump (5.7.0 → 5.7.1) after merge.

https://claude.ai/code/session_01LJkzsGCE8z1iashdakjRbR

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJkzsGCE8z1iashdakjRbR)_