### PR TITLE
fix(2014): Fix level query to be the same as CR query

### DIFF
--- a/src/controllers/api/2014/classController.ts
+++ b/src/controllers/api/2014/classController.ts
@@ -233,7 +233,7 @@ export const showSpellsForClass = async (req: Request, res: Response, next: Next
     }
 
     if (level !== undefined) {
-      findQuery.level = { $in: level.map(Number) }
+      findQuery.level = { $in: level }
     }
 
     const data = await Spell.find(findQuery)

--- a/src/controllers/api/2014/spellController.ts
+++ b/src/controllers/api/2014/spellController.ts
@@ -28,7 +28,7 @@ export const index = async (req: Request, res: Response, next: NextFunction) => 
     }
 
     if (level !== undefined) {
-      searchQueries.level = { $in: level.map(Number) }
+      searchQueries.level = { $in: level }
     }
 
     if (school !== undefined) {

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -37,14 +37,22 @@ export const LevelParamsSchema = ShowParamsSchema.extend({
 
 // --- Specific Controller Schemas ---
 
+/**
+ * Shared transform for numeric list query params that accept comma-separated values.
+ * Handles single strings, arrays, and comma-separated strings (e.g. "1,2" or "1%2C2").
+ * Non-numeric tokens are silently dropped.
+ */
+const transformNumericList = (val: string | string[] | undefined) => {
+  if (val == null || val === '' || (Array.isArray(val) && val.length === 0)) return undefined
+  const arr = Array.isArray(val) ? val : [val]
+  const flattened = arr.flatMap((item) => item.split(','))
+  const numbers = flattened.map(Number).filter((item) => !isNaN(item))
+  return numbers.length > 0 ? numbers : undefined
+}
+
 // Schemas from api/2014/spellController.ts
 export const SpellIndexQuerySchema = NameQuerySchema.extend({
-  level: z
-    .string()
-    .regex(/^\d+$/)
-    .or(z.array(z.string().regex(/^\d+$/)))
-    .optional()
-    .transform(ensureArrayOrUndefined),
+  level: z.string().or(z.string().array()).optional().transform(transformNumericList),
   school: z.string().or(z.array(z.string())).optional().transform(ensureArrayOrUndefined)
 })
 
@@ -54,18 +62,7 @@ export const ClassLevelsQuerySchema = z.object({
 })
 
 // Schemas from api/2014/monsterController.ts
-// --- Helper Transformation (for MonsterIndexQuerySchema) ---
-const transformChallengeRating = (val: string | string[] | undefined) => {
-  if (val == null || val === '' || (Array.isArray(val) && val.length === 0)) return undefined
-  // Ensure it's an array, handling both single string and array inputs
-  const arr = Array.isArray(val) ? val : [val]
-  // Flatten in case of comma-separated strings inside the array, then split
-  const flattened = arr.flatMap((item) => item.split(','))
-  // Convert to numbers and filter out NaNs
-  const numbers = flattened.map(Number).filter((item) => !isNaN(item))
-  // Return undefined if no valid numbers result, otherwise return the array
-  return numbers.length > 0 ? numbers : undefined
-}
+const transformChallengeRating = transformNumericList
 
 export const MonsterIndexQuerySchema = NameQuerySchema.extend({
   challenge_rating: z.string().or(z.string().array()).optional().transform(transformChallengeRating)

--- a/src/tests/controllers/api/2014/classController.test.ts
+++ b/src/tests/controllers/api/2014/classController.test.ts
@@ -364,7 +364,7 @@ describe('ClassController', () => {
       expect(mockNext).not.toHaveBeenCalled()
     })
 
-    it('returns spells filtered by multiple levels', async () => {
+    it('filters by multiple levels via repeated param', async () => {
       const classData = classFactory.build({ index: classIndex, url: classUrl })
       await ClassModel.insertMany([classData])
       const spellsLevel1 = spellFactory.buildList(2, {
@@ -383,6 +383,41 @@ describe('ClassController', () => {
 
       const request = createRequest({
         query: { level: ['1', '3'] },
+        params: { index: classIndex }
+      })
+      const response = createResponse()
+
+      await ClassController.showSpellsForClass(request, response, mockNext)
+
+      expect(response.statusCode).toBe(200)
+      const responseData = JSON.parse(response._getData())
+      expect(responseData.count).toBe(3) // 2 level 1 + 1 level 3
+      expect(responseData.results).toHaveLength(3)
+      responseData.results.forEach((spell: any) => {
+        expect([1, 3]).toContain(spell.level)
+      })
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it('filters by multiple levels via comma-separated string', async () => {
+      const classData = classFactory.build({ index: classIndex, url: classUrl })
+      await ClassModel.insertMany([classData])
+      const spellsLevel1 = spellFactory.buildList(2, {
+        level: 1,
+        classes: [{ index: classIndex, name: classData.name, url: classUrl }]
+      })
+      const spellsLevel2 = spellFactory.buildList(1, {
+        level: 2,
+        classes: [{ index: classIndex, name: classData.name, url: classUrl }]
+      })
+      const spellsLevel3 = spellFactory.buildList(1, {
+        level: 3,
+        classes: [{ index: classIndex, name: classData.name, url: classUrl }]
+      })
+      await SpellModel.insertMany([...spellsLevel1, ...spellsLevel2, ...spellsLevel3])
+
+      const request = createRequest({
+        query: { level: '1,3' }, // comma-separated, the bug case
         params: { index: classIndex }
       })
       const response = createResponse()
@@ -429,40 +464,52 @@ describe('ClassController', () => {
       expect(mockNext).not.toHaveBeenCalled()
     })
 
-    it('returns 400 for invalid level parameter (non-numeric string)', async () => {
+    it('ignores all-invalid level tokens and returns all class spells', async () => {
       const classData = classFactory.build({ index: classIndex, url: classUrl })
       await ClassModel.insertMany([classData])
+      const spells = spellFactory.buildList(3, {
+        classes: [{ index: classIndex, name: classData.name, url: classUrl }]
+      })
+      await SpellModel.insertMany(spells)
+
       const request = createRequest({ query: { level: 'abc' }, params: { index: classIndex } })
       const response = createResponse()
 
       await ClassController.showSpellsForClass(request, response, mockNext)
 
-      expect(response.statusCode).toBe(400)
+      expect(response.statusCode).toBe(200)
       const responseData = JSON.parse(response._getData())
-      expect(responseData.error).toBe('Invalid query parameters')
-      expect(responseData.details).toBeInstanceOf(Array)
-      expect(responseData.details[0].path).toEqual(['level'])
-      expect(responseData.details[0].message).toContain('Invalid')
+      expect(responseData.count).toBe(3)
       expect(mockNext).not.toHaveBeenCalled()
     })
 
-    it('returns 400 for invalid level parameter (in an array)', async () => {
+    it('drops invalid tokens from an array and filters by the remaining valid levels', async () => {
       const classData = classFactory.build({ index: classIndex, url: classUrl })
       await ClassModel.insertMany([classData])
+      const spellsLevel1 = spellFactory.buildList(2, {
+        level: 1,
+        classes: [{ index: classIndex, name: classData.name, url: classUrl }]
+      })
+      const spellsLevel2 = spellFactory.buildList(1, {
+        level: 2,
+        classes: [{ index: classIndex, name: classData.name, url: classUrl }]
+      })
+      await SpellModel.insertMany([...spellsLevel1, ...spellsLevel2])
+
       const request = createRequest({
-        query: { level: ['1', 'abc'] },
+        query: { level: ['1', 'abc'] }, // 'abc' dropped → only level 1 filter applied
         params: { index: classIndex }
       })
       const response = createResponse()
 
       await ClassController.showSpellsForClass(request, response, mockNext)
 
-      expect(response.statusCode).toBe(400)
+      expect(response.statusCode).toBe(200)
       const responseData = JSON.parse(response._getData())
-      expect(responseData.error).toBe('Invalid query parameters')
-      expect(responseData.details).toBeInstanceOf(Array)
-      expect(responseData.details[0].path).toEqual(['level', 1])
-      expect(responseData.details[0].message).toContain('Invalid')
+      expect(responseData.count).toBe(2)
+      responseData.results.forEach((spell: any) => {
+        expect(spell.level).toBe(1)
+      })
       expect(mockNext).not.toHaveBeenCalled()
     })
 

--- a/src/tests/controllers/api/2014/spellController.test.ts
+++ b/src/tests/controllers/api/2014/spellController.test.ts
@@ -54,28 +54,34 @@ describe('SpellController', () => {
       expect(mockNext).not.toHaveBeenCalled()
     })
 
-    // Filters test remains the same
-    it('filters spells by level', async () => {
-      const spellsData = [
-        spellFactory.build({ level: 1, name: 'Spell A' }),
-        spellFactory.build({ level: 2, name: 'Spell B' }),
-        spellFactory.build({ level: 1, name: 'Spell C' })
+    describe('with level query', () => {
+      const levelTestCases = [
+        { input: '1', expectedCount: 2, seedLevels: [1, 2, 1] },
+        { input: '1,2', expectedCount: 3, seedLevels: [1, 2, 1] }, // comma-separated (the bug case)
+        { input: ['1', '2'], expectedCount: 2, seedLevels: [1, 2, 3] }, // repeated param array
+        { input: 'abc,1,def,2', expectedCount: 2, seedLevels: [1, 2, 3] }, // mixed valid/invalid tokens
+        { input: ['3', 'xyz', '5'], expectedCount: 2, seedLevels: [3, 5, 7] }, // array with invalid
+        { input: 'invalid', expectedCount: 3, seedLevels: [1, 2, 3] }, // all invalid → no filter applied
+        { input: '', expectedCount: 3, seedLevels: [1, 2, 3] } // empty → no filter applied
       ]
-      await SpellModel.insertMany(spellsData)
 
-      const request = createRequest({ query: { level: '1' } })
-      const response = createResponse()
+      it.each(levelTestCases)('handles level: $input', async ({ input, expectedCount, seedLevels }) => {
+        const spellsToSeed = seedLevels.map((lvl, i) =>
+          spellFactory.build({ level: lvl, name: `Spell ${i}` })
+        )
+        await SpellModel.insertMany(spellsToSeed)
 
-      await SpellController.index(request, response, mockNext)
+        const request = createRequest({ query: { level: input } })
+        const response = createResponse()
 
-      expect(response.statusCode).toBe(200)
-      const responseData = JSON.parse(response._getData())
-      expect(responseData.count).toBe(2)
-      expect(responseData.results).toHaveLength(2)
-      expect(responseData.results.map((r: any) => r.index)).toEqual(
-        expect.arrayContaining([spellsData[0].index, spellsData[2].index])
-      )
-      expect(mockNext).not.toHaveBeenCalled()
+        await SpellController.index(request, response, mockNext)
+
+        expect(response.statusCode).toBe(200)
+        const responseData = JSON.parse(response._getData())
+        expect(responseData.count).toBe(expectedCount)
+        expect(responseData.results).toHaveLength(expectedCount)
+        expect(mockNext).not.toHaveBeenCalled()
+      })
     })
 
     it('returns an empty list when no spells exist', async () => {


### PR DESCRIPTION
## What does this do?

Causes level query to use the same logic as CR query.

## How was it tested?

CI/CD + Added/Updated a number of tests

## Is there a Github issue this is resolving?

This resolves #1102 

## Here's a fun image for your troubles

<img width="640" height="640" alt="image" src="https://github.com/user-attachments/assets/5594e7db-cec7-4163-a174-a7080a4356ba" />