### PR TITLE
feat(2024): add features and poisons endpoints with corresponding models, controllers, and tests

### DIFF
--- a/src/controllers/api/2024/featureController.ts
+++ b/src/controllers/api/2024/featureController.ts
@@ -1,0 +1,4 @@
+import SimpleController from '@/controllers/simpleController'
+import Feature2024Model from '@/models/2024/feature'
+
+export default new SimpleController(Feature2024Model)

--- a/src/controllers/api/2024/poisonController.ts
+++ b/src/controllers/api/2024/poisonController.ts
@@ -1,0 +1,4 @@
+import SimpleController from '@/controllers/simpleController'
+import Poison2024Model from '@/models/2024/poison'
+
+export default new SimpleController(Poison2024Model)

--- a/src/graphql/2024/resolvers/feature/args.ts
+++ b/src/graphql/2024/resolvers/feature/args.ts
@@ -1,0 +1,88 @@
+import { ArgsType, Field, InputType, registerEnumType } from 'type-graphql'
+import { z } from 'zod'
+
+import {
+  BaseFilterArgs,
+  BaseFilterArgsSchema,
+  BaseIndexArgs,
+  BaseIndexArgsSchema,
+  BaseOrderInterface
+} from '@/graphql/common/args'
+import { OrderByDirection } from '@/graphql/common/enums'
+
+export enum FeatureOrderField {
+  NAME = 'name',
+  LEVEL = 'level',
+  CLASS = 'class',
+  SUBCLASS = 'subclass'
+}
+
+export const FEATURE_SORT_FIELD_MAP: Record<FeatureOrderField, string> = {
+  [FeatureOrderField.NAME]: 'name',
+  [FeatureOrderField.LEVEL]: 'level.index',
+  [FeatureOrderField.CLASS]: 'class.name',
+  [FeatureOrderField.SUBCLASS]: 'subclass.name'
+}
+
+registerEnumType(FeatureOrderField, {
+  name: 'Feature2024OrderField',
+  description: 'Fields to sort 2024 Features by'
+})
+
+@InputType()
+export class FeatureOrder implements BaseOrderInterface<FeatureOrderField> {
+  @Field(() => FeatureOrderField)
+  by!: FeatureOrderField
+
+  @Field(() => OrderByDirection)
+  direction!: OrderByDirection
+
+  @Field(() => FeatureOrder, { nullable: true })
+  then_by?: FeatureOrder
+}
+
+export const FeatureOrderSchema: z.ZodType<FeatureOrder> = z.lazy(() =>
+  z.object({
+    by: z.nativeEnum(FeatureOrderField),
+    direction: z.nativeEnum(OrderByDirection),
+    then_by: FeatureOrderSchema.optional()
+  })
+)
+
+export const FeatureArgsSchema = z.object({
+  ...BaseFilterArgsSchema.shape,
+  level: z.array(z.string()).optional(),
+  class: z.array(z.string()).optional(),
+  subclass: z.array(z.string()).optional(),
+  order: FeatureOrderSchema.optional()
+})
+
+export const FeatureIndexArgsSchema = BaseIndexArgsSchema
+export { BaseIndexArgs as FeatureIndexArgs }
+
+@ArgsType()
+export class FeatureArgs extends BaseFilterArgs {
+  @Field(() => [String], {
+    nullable: true,
+    description: 'Filter by one or more level indices.'
+  })
+  level?: string[]
+
+  @Field(() => [String], {
+    nullable: true,
+    description: 'Filter by one or more associated class indices.'
+  })
+  class?: string[]
+
+  @Field(() => [String], {
+    nullable: true,
+    description: 'Filter by one or more associated subclass indices.'
+  })
+  subclass?: string[]
+
+  @Field(() => FeatureOrder, {
+    nullable: true,
+    description: 'Specify sorting order for 2024 features.'
+  })
+  order?: FeatureOrder
+}

--- a/src/graphql/2024/resolvers/feature/resolver.ts
+++ b/src/graphql/2024/resolvers/feature/resolver.ts
@@ -1,0 +1,85 @@
+import { Args, FieldResolver, Query, Resolver, Root } from 'type-graphql'
+
+import { buildSortPipeline } from '@/graphql/common/args'
+import { resolveSingleReference } from '@/graphql/utils/resolvers'
+import Class2024Model, { Class2024 } from '@/models/2024/class'
+import Feature2024Model, { Feature2024 } from '@/models/2024/feature'
+import Subclass2024Model, { Subclass2024 } from '@/models/2024/subclass'
+import { escapeRegExp } from '@/util'
+
+import {
+  FEATURE_SORT_FIELD_MAP,
+  FeatureArgs,
+  FeatureArgsSchema,
+  FeatureIndexArgs,
+  FeatureIndexArgsSchema,
+  FeatureOrderField
+} from './args'
+
+@Resolver(Feature2024)
+export class FeatureResolver {
+  @Query(() => [Feature2024], {
+    description: 'Gets all 2024 features, optionally filtered and sorted.'
+  })
+  async features(@Args(() => FeatureArgs) args: FeatureArgs): Promise<Feature2024[]> {
+    const validatedArgs = FeatureArgsSchema.parse(args)
+
+    const query = Feature2024Model.find()
+    const filters: any[] = []
+
+    if (validatedArgs.name != null && validatedArgs.name !== '') {
+      filters.push({ name: { $regex: new RegExp(escapeRegExp(validatedArgs.name), 'i') } })
+    }
+    if (validatedArgs.level && validatedArgs.level.length > 0) {
+      filters.push({ 'level.index': { $in: validatedArgs.level } })
+    }
+    if (validatedArgs.class && validatedArgs.class.length > 0) {
+      filters.push({ 'class.index': { $in: validatedArgs.class } })
+    }
+    if (validatedArgs.subclass && validatedArgs.subclass.length > 0) {
+      filters.push({ 'subclass.index': { $in: validatedArgs.subclass } })
+    }
+
+    if (filters.length > 0) {
+      query.where({ $and: filters })
+    }
+
+    const sortQuery = buildSortPipeline<FeatureOrderField>({
+      order: validatedArgs.order,
+      sortFieldMap: FEATURE_SORT_FIELD_MAP,
+      defaultSortField: FeatureOrderField.NAME
+    })
+
+    if (Object.keys(sortQuery).length > 0) {
+      query.sort(sortQuery)
+    }
+
+    if (validatedArgs.skip !== undefined) {
+      query.skip(validatedArgs.skip)
+    }
+    if (validatedArgs.limit !== undefined) {
+      query.limit(validatedArgs.limit)
+    }
+
+    return query.lean()
+  }
+
+  @Query(() => Feature2024, {
+    nullable: true,
+    description: 'Gets a single 2024 feature by index.'
+  })
+  async feature(@Args(() => FeatureIndexArgs) args: FeatureIndexArgs): Promise<Feature2024 | null> {
+    const { index } = FeatureIndexArgsSchema.parse(args)
+    return Feature2024Model.findOne({ index }).lean()
+  }
+
+  @FieldResolver(() => Class2024, { nullable: true })
+  async class(@Root() feature: Feature2024): Promise<Class2024 | null> {
+    return resolveSingleReference(feature.class, Class2024Model)
+  }
+
+  @FieldResolver(() => Subclass2024, { nullable: true })
+  async subclass(@Root() feature: Feature2024): Promise<Subclass2024 | null> {
+    return resolveSingleReference(feature.subclass, Subclass2024Model)
+  }
+}

--- a/src/graphql/2024/resolvers/index.ts
+++ b/src/graphql/2024/resolvers/index.ts
@@ -14,6 +14,7 @@ import { DamageTypeResolver } from './damageType/resolver'
 import { ContentFieldResolver, EquipmentResolver, ToolResolver } from './equipment/resolver'
 import { EquipmentCategoryResolver } from './equipmentCategory/resolver'
 import { FeatResolver } from './feat/resolver'
+import { FeatureResolver } from './feature/resolver'
 import { LanguageResolver } from './language/resolver'
 import { LocaleResolver } from './locale/resolver'
 import { MagicItemResolver } from './magicItem/resolver'
@@ -25,6 +26,7 @@ import {
   MonsterProficiency2024Resolver,
   MonsterSpellcasting2024Resolver
 } from './monster/resolver'
+import { PoisonResolver } from './poison/resolver'
 import { ProficiencyResolver } from './proficiency/resolver'
 import { SkillResolver } from './skill/resolver'
 import { SpeciesResolver } from './species/resolver'
@@ -45,10 +47,12 @@ const collectionResolvers = [
   EquipmentResolver,
   EquipmentCategoryResolver,
   FeatResolver,
+  FeatureResolver,
   LanguageResolver,
   MagicItemResolver,
   MagicSchoolResolver,
   Monster2024Resolver,
+  PoisonResolver,
   ProficiencyResolver,
   SkillResolver,
   SpeciesResolver,

--- a/src/graphql/2024/resolvers/poison/args.ts
+++ b/src/graphql/2024/resolvers/poison/args.ts
@@ -1,0 +1,80 @@
+import { ArgsType, Field, InputType, registerEnumType } from 'type-graphql'
+import { z } from 'zod'
+
+import {
+  BaseFilterArgs,
+  BaseFilterArgsSchema,
+  BaseIndexArgs,
+  BaseIndexArgsSchema,
+  BaseOrderInterface
+} from '@/graphql/common/args'
+import { OrderByDirection } from '@/graphql/common/enums'
+import { NumberFilterInput, NumberFilterInputSchema } from '@/graphql/common/inputs'
+
+export enum PoisonOrderField {
+  NAME = 'name',
+  COST = 'cost',
+  TYPE = 'type'
+}
+
+export const POISON_SORT_FIELD_MAP: Record<PoisonOrderField, string> = {
+  [PoisonOrderField.NAME]: 'name',
+  [PoisonOrderField.COST]: 'cost',
+  [PoisonOrderField.TYPE]: 'type'
+}
+
+registerEnumType(PoisonOrderField, {
+  name: 'Poison2024OrderField',
+  description: 'Fields to sort 2024 Poisons by'
+})
+
+@InputType()
+export class PoisonOrder implements BaseOrderInterface<PoisonOrderField> {
+  @Field(() => PoisonOrderField)
+  by!: PoisonOrderField
+
+  @Field(() => OrderByDirection)
+  direction!: OrderByDirection
+
+  @Field(() => PoisonOrder, { nullable: true })
+  then_by?: PoisonOrder
+}
+
+export const PoisonOrderSchema: z.ZodType<PoisonOrder> = z.lazy(() =>
+  z.object({
+    by: z.nativeEnum(PoisonOrderField),
+    direction: z.nativeEnum(OrderByDirection),
+    then_by: PoisonOrderSchema.optional()
+  })
+)
+
+export const PoisonArgsSchema = z.object({
+  ...BaseFilterArgsSchema.shape,
+  cost: NumberFilterInputSchema.optional(),
+  type: z.array(z.string()).optional(),
+  order: PoisonOrderSchema.optional()
+})
+
+export const PoisonIndexArgsSchema = BaseIndexArgsSchema
+export { BaseIndexArgs as PoisonIndexArgs }
+
+@ArgsType()
+export class PoisonArgs extends BaseFilterArgs {
+  @Field(() => NumberFilterInput, {
+    nullable: true,
+    description: 'Filter by cost. Allows exact match, list, or range.'
+  })
+  cost?: NumberFilterInput
+
+  @Field(() => [String], {
+    nullable: true,
+    description: 'Filter by one or more poison delivery types.'
+  })
+  type?: string[]
+
+  @Field(() => PoisonOrder, {
+    nullable: true,
+    description: 'Specify sorting order for 2024 poisons.'
+  })
+  order?: PoisonOrder
+}

--- a/src/graphql/2024/resolvers/poison/resolver.ts
+++ b/src/graphql/2024/resolvers/poison/resolver.ts
@@ -1,0 +1,73 @@
+import { Args, Query, Resolver } from 'type-graphql'
+
+import { buildSortPipeline } from '@/graphql/common/args'
+import { buildMongoQueryFromNumberFilter } from '@/graphql/common/inputs'
+import Poison2024Model, { Poison2024 } from '@/models/2024/poison'
+import { escapeRegExp } from '@/util'
+
+import {
+  POISON_SORT_FIELD_MAP,
+  PoisonArgs,
+  PoisonArgsSchema,
+  PoisonIndexArgs,
+  PoisonIndexArgsSchema,
+  PoisonOrderField
+} from './args'
+
+@Resolver(Poison2024)
+export class PoisonResolver {
+  @Query(() => [Poison2024], {
+    description: 'Gets all 2024 poisons, optionally filtered and sorted.'
+  })
+  async poisons(@Args(() => PoisonArgs) args: PoisonArgs): Promise<Poison2024[]> {
+    const validatedArgs = PoisonArgsSchema.parse(args)
+
+    const query = Poison2024Model.find()
+    const filters: any[] = []
+
+    if (validatedArgs.name != null && validatedArgs.name !== '') {
+      filters.push({ name: { $regex: new RegExp(escapeRegExp(validatedArgs.name), 'i') } })
+    }
+    if (validatedArgs.type && validatedArgs.type.length > 0) {
+      filters.push({ type: { $in: validatedArgs.type } })
+    }
+    if (validatedArgs.cost) {
+      const costQuery = buildMongoQueryFromNumberFilter(validatedArgs.cost)
+      if (costQuery) {
+        filters.push({ cost: costQuery })
+      }
+    }
+
+    if (filters.length > 0) {
+      query.where({ $and: filters })
+    }
+
+    const sortQuery = buildSortPipeline<PoisonOrderField>({
+      order: validatedArgs.order,
+      sortFieldMap: POISON_SORT_FIELD_MAP,
+      defaultSortField: PoisonOrderField.NAME
+    })
+
+    if (Object.keys(sortQuery).length > 0) {
+      query.sort(sortQuery)
+    }
+
+    if (validatedArgs.skip !== undefined) {
+      query.skip(validatedArgs.skip)
+    }
+    if (validatedArgs.limit !== undefined) {
+      query.limit(validatedArgs.limit)
+    }
+
+    return query.lean()
+  }
+
+  @Query(() => Poison2024, {
+    nullable: true,
+    description: 'Gets a single 2024 poison by index.'
+  })
+  async poison(@Args(() => PoisonIndexArgs) args: PoisonIndexArgs): Promise<Poison2024 | null> {
+    const { index } = PoisonIndexArgsSchema.parse(args)
+    return Poison2024Model.findOne({ index }).lean()
+  }
+}

--- a/src/models/2024/feature.ts
+++ b/src/models/2024/feature.ts
@@ -1,0 +1,51 @@
+import { getModelForClass, prop } from '@typegoose/typegoose'
+import { DocumentType } from '@typegoose/typegoose/lib/types'
+import { Field, ObjectType } from 'type-graphql'
+
+import { Class2024 } from '@/models/2024/class'
+import { Subclass2024 } from '@/models/2024/subclass'
+import { APIReference } from '@/models/common/apiReference'
+import { srdModelOptions } from '@/util/modelOptions'
+
+@ObjectType({ description: 'A 2024 class or subclass feature.' })
+@srdModelOptions('2024-features')
+export class Feature2024 {
+  @Field(() => String, { description: 'The unique identifier for this feature.' })
+  @prop({ required: true, index: true, type: () => String })
+  public index!: string
+
+  @Field(() => String, { description: 'The name of this feature.' })
+  @prop({ required: true, index: true, type: () => String })
+  public name!: string
+
+  @Field(() => String, { description: 'Description of the feature.' })
+  @prop({ required: true, type: () => String })
+  public description!: string
+
+  @Field(() => APIReference, { description: 'The level at which this feature is gained.' })
+  @prop({ type: () => APIReference, required: true })
+  public level!: APIReference
+
+  @Field(() => Class2024, { description: 'The class that gains this feature.' })
+  @prop({ type: () => APIReference, required: true })
+  public class!: APIReference
+
+  @Field(() => Subclass2024, {
+    nullable: true,
+    description: 'The subclass that gains this feature, if applicable.'
+  })
+  @prop({ type: () => APIReference })
+  public subclass?: APIReference
+
+  @prop({ required: true, index: true, type: () => String })
+  public url!: string
+
+  @Field(() => String, { description: 'Timestamp of the last update.' })
+  @prop({ required: true, index: true, type: () => String })
+  public updated_at!: string
+}
+
+export type Feature2024Document = DocumentType<Feature2024>
+const Feature2024Model = getModelForClass(Feature2024)
+
+export default Feature2024Model

--- a/src/models/2024/poison.ts
+++ b/src/models/2024/poison.ts
@@ -1,0 +1,41 @@
+import { getModelForClass, prop } from '@typegoose/typegoose'
+import { DocumentType } from '@typegoose/typegoose/lib/types'
+import { Field, Int, ObjectType } from 'type-graphql'
+
+import { srdModelOptions } from '@/util/modelOptions'
+
+@ObjectType({ description: 'A 2024 poison.' })
+@srdModelOptions('2024-poisons')
+export class Poison2024 {
+  @Field(() => String, { description: 'The unique identifier for this poison.' })
+  @prop({ required: true, index: true, type: () => String })
+  public index!: string
+
+  @Field(() => String, { description: 'The name of this poison.' })
+  @prop({ required: true, index: true, type: () => String })
+  public name!: string
+
+  @Field(() => Int, { description: 'The poison cost in gold pieces.' })
+  @prop({ required: true, index: true, type: () => Number })
+  public cost!: number
+
+  @Field(() => String, { description: 'The poison delivery type.' })
+  @prop({ required: true, index: true, type: () => String })
+  public type!: string
+
+  @Field(() => String, { description: 'Description of the poison.' })
+  @prop({ required: true, type: () => String })
+  public description!: string
+
+  @prop({ required: true, index: true, type: () => String })
+  public url!: string
+
+  @Field(() => String, { description: 'Timestamp of the last update.' })
+  @prop({ required: true, index: true, type: () => String })
+  public updated_at!: string
+}
+
+export type Poison2024Document = DocumentType<Poison2024>
+const Poison2024Model = getModelForClass(Poison2024)
+
+export default Poison2024Model

--- a/src/routes/api/2024.ts
+++ b/src/routes/api/2024.ts
@@ -11,11 +11,13 @@ import DamageTypesHandler from './2024/damageTypes'
 import EquipmentHandler from './2024/equipment'
 import EquipmentCategoriesHandler from './2024/equipmentCategories'
 import FeatsHandler from './2024/feats'
+import FeaturesHandler from './2024/features'
 import LanguagesHandler from './2024/languages'
 import LocalesHandler from './2024/locales'
 import MagicItemsHandler from './2024/magicItems'
 import MagicSchoolsHandler from './2024/magicSchools'
 import MonstersHandler from './2024/monsters'
+import PoisonsHandler from './2024/poisons'
 import ProficienciesHandler from './2024/proficiencies'
 import SkillsHandler from './2024/skills'
 import SpeciesHandler from './2024/species'
@@ -40,11 +42,13 @@ router.use('/damage-types', DamageTypesHandler)
 router.use('/equipment', EquipmentHandler)
 router.use('/equipment-categories', EquipmentCategoriesHandler)
 router.use('/feats', FeatsHandler)
+router.use('/features', FeaturesHandler)
 router.use('/languages', LanguagesHandler)
 router.use('/locales', LocalesHandler)
 router.use('/magic-items', MagicItemsHandler)
 router.use('/magic-schools', MagicSchoolsHandler)
 router.use('/monsters', MonstersHandler)
+router.use('/poisons', PoisonsHandler)
 router.use('/proficiencies', ProficienciesHandler)
 router.use('/skills', SkillsHandler)
 router.use('/species', SpeciesHandler)

--- a/src/routes/api/2024/features.ts
+++ b/src/routes/api/2024/features.ts
@@ -1,0 +1,15 @@
+import * as express from 'express'
+
+import FeatureController from '@/controllers/api/2024/featureController'
+
+const router = express.Router()
+
+router.get('/', function (req, res, next) {
+  FeatureController.index(req, res, next)
+})
+
+router.get('/:index', function (req, res, next) {
+  FeatureController.show(req, res, next)
+})
+
+export default router

--- a/src/routes/api/2024/poisons.ts
+++ b/src/routes/api/2024/poisons.ts
@@ -1,0 +1,15 @@
+import * as express from 'express'
+
+import PoisonController from '@/controllers/api/2024/poisonController'
+
+const router = express.Router()
+
+router.get('/', function (req, res, next) {
+  PoisonController.index(req, res, next)
+})
+
+router.get('/:index', function (req, res, next) {
+  PoisonController.show(req, res, next)
+})
+
+export default router

--- a/src/tests/controllers/api/2024/featureController.test.ts
+++ b/src/tests/controllers/api/2024/featureController.test.ts
@@ -1,0 +1,84 @@
+import { createRequest, createResponse } from 'node-mocks-http'
+import { describe, expect, it, vi } from 'vitest'
+
+import FeatureController from '@/controllers/api/2024/featureController'
+import Feature2024Model from '@/models/2024/feature'
+import { featureFactory } from '@/tests/factories/2024/feature.factory'
+import { mockNext as defaultMockNext } from '@/tests/support'
+import {
+  generateUniqueDbUri,
+  setupIsolatedDatabase,
+  setupModelCleanup,
+  teardownIsolatedDatabase
+} from '@/tests/support/db'
+
+const mockNext = vi.fn(defaultMockNext)
+
+const dbUri = generateUniqueDbUri('feature_2024')
+
+setupIsolatedDatabase(dbUri)
+teardownIsolatedDatabase()
+setupModelCleanup(Feature2024Model)
+
+describe('FeatureController', () => {
+  describe('index', () => {
+    it('returns a list of features', async () => {
+      const featuresData = featureFactory.buildList(3)
+      await Feature2024Model.insertMany(featuresData)
+      const request = createRequest({ query: {} })
+      const response = createResponse()
+
+      await FeatureController.index(request, response, mockNext)
+
+      expect(response.statusCode).toBe(200)
+      const responseData = JSON.parse(response._getData())
+      expect(responseData.count).toBe(3)
+      expect(responseData.results).toHaveLength(3)
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it('filters by name', async () => {
+      const featuresData = [
+        featureFactory.build({ name: 'Rage' }),
+        featureFactory.build({ name: 'Spellcasting' })
+      ]
+      await Feature2024Model.insertMany(featuresData)
+      const request = createRequest({ query: { name: 'Rage' } })
+      const response = createResponse()
+
+      await FeatureController.index(request, response, mockNext)
+
+      expect(response.statusCode).toBe(200)
+      const responseData = JSON.parse(response._getData())
+      expect(responseData.count).toBe(1)
+      expect(responseData.results[0].name).toBe('Rage')
+    })
+  })
+
+  describe('show', () => {
+    it('returns a single feature when found', async () => {
+      const featureData = featureFactory.build({ index: 'barbarian-rage', name: 'Rage' })
+      await Feature2024Model.insertMany([featureData])
+      const request = createRequest({ params: { index: 'barbarian-rage' } })
+      const response = createResponse()
+
+      await FeatureController.show(request, response, mockNext)
+
+      expect(response.statusCode).toBe(200)
+      const responseData = JSON.parse(response._getData())
+      expect(responseData.index).toBe('barbarian-rage')
+      expect(responseData.name).toBe('Rage')
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it('calls next() when the feature is not found', async () => {
+      const request = createRequest({ params: { index: 'nonexistent' } })
+      const response = createResponse()
+
+      await FeatureController.show(request, response, mockNext)
+
+      expect(response._getData()).toBe('')
+      expect(mockNext).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/src/tests/controllers/api/2024/poisonController.test.ts
+++ b/src/tests/controllers/api/2024/poisonController.test.ts
@@ -1,0 +1,87 @@
+import { createRequest, createResponse } from 'node-mocks-http'
+import { describe, expect, it, vi } from 'vitest'
+
+import PoisonController from '@/controllers/api/2024/poisonController'
+import Poison2024Model from '@/models/2024/poison'
+import { poisonFactory } from '@/tests/factories/2024/poison.factory'
+import { mockNext as defaultMockNext } from '@/tests/support'
+import {
+  generateUniqueDbUri,
+  setupIsolatedDatabase,
+  setupModelCleanup,
+  teardownIsolatedDatabase
+} from '@/tests/support/db'
+
+const mockNext = vi.fn(defaultMockNext)
+
+const dbUri = generateUniqueDbUri('poison_2024')
+
+setupIsolatedDatabase(dbUri)
+teardownIsolatedDatabase()
+setupModelCleanup(Poison2024Model)
+
+describe('PoisonController', () => {
+  describe('index', () => {
+    it('returns a list of poisons', async () => {
+      const poisonsData = poisonFactory.buildList(3)
+      await Poison2024Model.insertMany(poisonsData)
+      const request = createRequest({ query: {} })
+      const response = createResponse()
+
+      await PoisonController.index(request, response, mockNext)
+
+      expect(response.statusCode).toBe(200)
+      const responseData = JSON.parse(response._getData())
+      expect(responseData.count).toBe(3)
+      expect(responseData.results).toHaveLength(3)
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it('filters by name', async () => {
+      const poisonsData = [
+        poisonFactory.build({ name: "Assassin's Blood" }),
+        poisonFactory.build({ name: 'Truth Serum' })
+      ]
+      await Poison2024Model.insertMany(poisonsData)
+      const request = createRequest({ query: { name: "Assassin's Blood" } })
+      const response = createResponse()
+
+      await PoisonController.index(request, response, mockNext)
+
+      expect(response.statusCode).toBe(200)
+      const responseData = JSON.parse(response._getData())
+      expect(responseData.count).toBe(1)
+      expect(responseData.results[0].name).toBe("Assassin's Blood")
+    })
+  })
+
+  describe('show', () => {
+    it('returns a single poison when found', async () => {
+      const poisonData = poisonFactory.build({
+        index: 'assassins-blood',
+        name: "Assassin's Blood"
+      })
+      await Poison2024Model.insertMany([poisonData])
+      const request = createRequest({ params: { index: 'assassins-blood' } })
+      const response = createResponse()
+
+      await PoisonController.show(request, response, mockNext)
+
+      expect(response.statusCode).toBe(200)
+      const responseData = JSON.parse(response._getData())
+      expect(responseData.index).toBe('assassins-blood')
+      expect(responseData.name).toBe("Assassin's Blood")
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it('calls next() when the poison is not found', async () => {
+      const request = createRequest({ params: { index: 'nonexistent' } })
+      const response = createResponse()
+
+      await PoisonController.show(request, response, mockNext)
+
+      expect(response._getData()).toBe('')
+      expect(mockNext).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/src/tests/factories/2024/feature.factory.ts
+++ b/src/tests/factories/2024/feature.factory.ts
@@ -1,0 +1,37 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import { Feature2024 } from '@/models/2024/feature'
+import { APIReference } from '@/models/common/apiReference'
+
+const apiReferenceFactory = Factory.define<APIReference>(() => ({
+  index: faker.lorem.slug(),
+  name: faker.lorem.words(2),
+  url: `/api/2024/${faker.lorem.slug()}`
+}))
+
+export const featureFactory = Factory.define<Feature2024>(({ sequence }) => {
+  const name = `Feature ${sequence} - ${faker.lorem.words(2)}`
+  const index = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+
+  return {
+    index,
+    name,
+    description: faker.lorem.paragraph(),
+    level: apiReferenceFactory.build({
+      index: `class-${sequence}`,
+      name: `Class ${sequence}`,
+      url: `/api/2024/levels/class-${sequence}`
+    }),
+    class: apiReferenceFactory.build({
+      index: `class-${sequence}`,
+      name: `Class ${sequence}`,
+      url: `/api/2024/classes/class-${sequence}`
+    }),
+    url: `/api/2024/features/${index}`,
+    updated_at: faker.date.recent().toISOString()
+  }
+})

--- a/src/tests/factories/2024/poison.factory.ts
+++ b/src/tests/factories/2024/poison.factory.ts
@@ -1,0 +1,24 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import { Poison2024 } from '@/models/2024/poison'
+
+const POISON_TYPES = ['contact', 'ingested', 'inhaled', 'injury'] as const
+
+export const poisonFactory = Factory.define<Poison2024>(({ sequence }) => {
+  const name = `Poison ${sequence} - ${faker.lorem.words(2)}`
+  const index = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+
+  return {
+    index,
+    name,
+    cost: faker.number.int({ min: 50, max: 2000 }),
+    type: faker.helpers.arrayElement(POISON_TYPES),
+    description: faker.lorem.paragraph(),
+    url: `/api/2024/poisons/${index}`,
+    updated_at: faker.date.recent().toISOString()
+  }
+})

--- a/src/tests/integration/api/2024/features.itest.ts
+++ b/src/tests/integration/api/2024/features.itest.ts
@@ -1,0 +1,70 @@
+import { Application } from 'express'
+import mongoose from 'mongoose'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import createApp from '@/server'
+import { mongodbUri, redisClient } from '@/util'
+
+let app: Application
+let server: any
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+beforeAll(async () => {
+  await mongoose.connect(mongodbUri)
+  await redisClient.connect()
+  app = await createApp()
+  server = app.listen()
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await redisClient.quit()
+  server.close()
+})
+
+describe('/api/2024/features', () => {
+  it('should list features', async () => {
+    const res = await request(app).get('/api/2024/features')
+    expect(res.statusCode).toEqual(200)
+    expect(res.body.results.length).not.toEqual(0)
+  })
+
+  describe('with name query', () => {
+    it('returns the named object', async () => {
+      const indexRes = await request(app).get('/api/2024/features')
+      const name = indexRes.body.results[0].name
+      const res = await request(app).get(`/api/2024/features?name=${name}`)
+      expect(res.statusCode).toEqual(200)
+      expect(res.body.results[0].name).toEqual(name)
+    })
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/2024/features')
+      const name = indexRes.body.results[0].name
+      const res = await request(app).get(`/api/2024/features?name=${name.toLowerCase()}`)
+      expect(res.statusCode).toEqual(200)
+      expect(res.body.results[0].name).toEqual(name)
+    })
+  })
+
+  describe('/api/2024/features/:index', () => {
+    it('should return one object', async () => {
+      const indexRes = await request(app).get('/api/2024/features')
+      const index = indexRes.body.results[0].index
+      const showRes = await request(app).get(`/api/2024/features/${index}`)
+      expect(showRes.statusCode).toEqual(200)
+      expect(showRes.body.index).toEqual(index)
+    })
+
+    describe('with an invalid index', () => {
+      it('should return 404', async () => {
+        const showRes = await request(app).get('/api/2024/features/invalid-index')
+        expect(showRes.statusCode).toEqual(404)
+      })
+    })
+  })
+})

--- a/src/tests/integration/api/2024/poisons.itest.ts
+++ b/src/tests/integration/api/2024/poisons.itest.ts
@@ -1,0 +1,70 @@
+import { Application } from 'express'
+import mongoose from 'mongoose'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import createApp from '@/server'
+import { mongodbUri, redisClient } from '@/util'
+
+let app: Application
+let server: any
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+beforeAll(async () => {
+  await mongoose.connect(mongodbUri)
+  await redisClient.connect()
+  app = await createApp()
+  server = app.listen()
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await redisClient.quit()
+  server.close()
+})
+
+describe('/api/2024/poisons', () => {
+  it('should list poisons', async () => {
+    const res = await request(app).get('/api/2024/poisons')
+    expect(res.statusCode).toEqual(200)
+    expect(res.body.results.length).not.toEqual(0)
+  })
+
+  describe('with name query', () => {
+    it('returns the named object', async () => {
+      const indexRes = await request(app).get('/api/2024/poisons')
+      const name = indexRes.body.results[0].name
+      const res = await request(app).get(`/api/2024/poisons?name=${name}`)
+      expect(res.statusCode).toEqual(200)
+      expect(res.body.results[0].name).toEqual(name)
+    })
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/2024/poisons')
+      const name = indexRes.body.results[0].name
+      const res = await request(app).get(`/api/2024/poisons?name=${name.toLowerCase()}`)
+      expect(res.statusCode).toEqual(200)
+      expect(res.body.results[0].name).toEqual(name)
+    })
+  })
+
+  describe('/api/2024/poisons/:index', () => {
+    it('should return one object', async () => {
+      const indexRes = await request(app).get('/api/2024/poisons')
+      const index = indexRes.body.results[0].index
+      const showRes = await request(app).get(`/api/2024/poisons/${index}`)
+      expect(showRes.statusCode).toEqual(200)
+      expect(showRes.body.index).toEqual(index)
+    })
+
+    describe('with an invalid index', () => {
+      it('should return 404', async () => {
+        const showRes = await request(app).get('/api/2024/poisons/invalid-index')
+        expect(showRes.statusCode).toEqual(404)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## What does this do?

- Adds the `Feature` and `Poison` resources for the 2024 ruleset, following the same REST/GraphQL/typegoose pattern used by other 2024 resources.
- REST: `GET /api/2024/features`, `GET /api/2024/features/:index`, `GET /api/2024/poisons`, `GET /api/2024/poisons/:index`.
- GraphQL: `feature2024`/`feature2024s` and `poison2024`/`poison2024s` queries, with filter/sort args (`level`, `class`, `subclass` for features; `cost`, `type` for poisons).
- Adds Mongoose/typegoose models (`Feature2024`, `Poison2024`) and corresponding test factories.

## How was it tested?

- Added controller unit tests (`featureController.test.ts`, `poisonController.test.ts`) and integration tests (`features.itest.ts`, `poisons.itest.ts`) covering the new REST endpoints.
- Lint, typecheck, and the full test suite run in CI.

## Is there a Github issue this is resolving?

N/A — part of ongoing 2024 ruleset endpoint coverage.

## Was any impacted documentation updated to reflect this change?

No documentation changes included; the new endpoints follow existing conventions and are self-documented via GraphQL schema descriptions.